### PR TITLE
docs: add 8 new articles and update 2 from zudo-text

### DIFF
--- a/src/content/docs-ja/extensions/palette-theme-integration.mdx
+++ b/src/content/docs-ja/extensions/palette-theme-integration.mdx
@@ -1,0 +1,241 @@
+---
+title: パレットベースのテーマシステム
+description: ANSI スタイルのパレット、color-mix() による不透明度、HighlightStyle タグマッピングを使い、CSS カスタムプロパティで完全に駆動される CodeMirror テーマの作成方法。
+sidebar_position: 7
+---
+
+# パレットベースのテーマシステム
+
+このページでは、ANSI ターミナルパレット規則に従う CSS カスタムプロパティからすべての色を取得するテーマアーキテクチャを解説します。CSS 変数が変更されるとエディターの外観が自動的に更新され、テーマの再構築や再設定は不要です。
+
+## パレット
+
+カラースキームは親要素の CSS カスタムプロパティとして定義されます。
+
+```css
+:root {
+  --palette-fg: #c0c0c0;
+  --palette-bg: #1e1e2e;
+  --palette-cursor: #f5e0dc;
+  --palette-selection: rgba(88, 91, 112, 0.5);
+
+  /* ANSI スタイルのパレット: 0-15 */
+  --palette-0: #11111b; /* black   -- サーフェス、ガター */
+  --palette-1: #f38ba8; /* red     -- 不正、エラー */
+  --palette-2: #a6e3a1; /* green   -- 文字列 */
+  --palette-3: #f9e2af; /* yellow  -- 数値、型 */
+  --palette-4: #89b4fa; /* blue    -- キーワード、見出し */
+  --palette-5: #cba6f7; /* magenta -- 関数、タグ */
+  --palette-6: #94e2d5; /* cyan    -- 演算子、リンク */
+  --palette-7: #bac2de; /* white   -- 句読点 */
+  --palette-8: #585b70; /* bright black -- コメント */
+  --palette-15: #6c7086; /* bright white -- 行番号 */
+}
+```
+
+このパレットは伝統的な 16 色 ANSI ターミナル規則にマッピングされ、シンタックスハイライトのカテゴリーへの自然なマッピングを提供します。
+
+## エディター UI テーマ
+
+エディターテーマはすべての色に CSS カスタムプロパティを使った `EditorView.theme()` を使用します。
+
+```ts
+import { EditorView } from "@codemirror/view";
+
+function createEditorColorTheme(isDark: boolean) {
+  const baseTheme = EditorView.theme(
+    {
+      "&": {
+        color: "var(--palette-fg)",
+        backgroundColor: "var(--palette-bg)",
+      },
+      ".cm-content": {
+        caretColor: "var(--palette-cursor)",
+      },
+      ".cm-cursor, .cm-dropCursor": {
+        borderLeftColor: "var(--palette-cursor)",
+      },
+      "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
+        {
+          backgroundColor: "var(--palette-selection)",
+        },
+      ".cm-panels": {
+        backgroundColor: "var(--palette-0)",
+        color: "var(--palette-fg)",
+      },
+      ".cm-gutters": {
+        backgroundColor: "var(--palette-bg)",
+        color: "var(--palette-15)",
+        border: "none",
+      },
+    },
+    { dark: isDark },
+  );
+
+  // ... (以下のハイライトスタイル)
+  return [baseTheme];
+}
+```
+
+`isDark` パラメーターは、これがダークテーマであることを CodeMirror に伝え、明示的にスタイル指定されていない UI 要素のデフォルトスタイルに影響します。
+
+## color-mix() による不透明度
+
+半透明のオーバーレイ（アクティブ行、検索マッチ、選択マッチ）では、`oklch` 色空間の `color-mix()` を使用します。
+
+```ts
+".cm-activeLine": {
+  backgroundColor: "color-mix(in oklch, var(--palette-fg) 4%, transparent)",
+},
+".cm-searchMatch": {
+  backgroundColor: "color-mix(in oklch, var(--palette-3) 30%, transparent)",
+  outline: "1px solid color-mix(in oklch, var(--palette-3) 50%, transparent)",
+},
+".cm-searchMatch.cm-searchMatch-selected": {
+  backgroundColor: "color-mix(in oklch, var(--palette-3) 50%, transparent)",
+},
+".cm-selectionMatch": {
+  backgroundColor: "color-mix(in oklch, var(--palette-selection) 50%, transparent)",
+},
+"&.cm-focused .cm-matchingBracket, &.cm-focused .cm-nonmatchingBracket": {
+  backgroundColor: "color-mix(in oklch, var(--palette-4) 25%, transparent)",
+},
+```
+
+<Tip>
+
+`color-mix(in oklch, var(--some-color) 30%, transparent)` はハードコードされた値の `rgba()` に代わるモダン CSS の手法です。任意の色形式で動作し、oklch 色空間で知覚的に均一なブレンディングを生成します。追加の変数を定義することなく、不透明なカスタムプロパティから半透明のバリアントを導出できます。
+
+</Tip>
+
+## HighlightStyle によるシンタックスハイライト
+
+ハイライトスタイルは Lezer タグをパレットの色にマッピングします。
+
+```ts
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags } from "@lezer/highlight";
+
+const highlightStyle = HighlightStyle.define([
+  // コメント
+  { tag: tags.comment, color: "var(--palette-8)" },
+
+  // キーワードと制御フロー
+  { tag: tags.keyword, color: "var(--palette-4)" },
+
+  // 関数とタグ
+  {
+    tag: [
+      tags.function(tags.variableName),
+      tags.function(tags.definition(tags.variableName)),
+      tags.tagName,
+    ],
+    color: "var(--palette-5)",
+  },
+
+  // 文字列
+  { tag: [tags.string, tags.special(tags.string)], color: "var(--palette-2)" },
+  { tag: tags.regexp, color: "var(--palette-6)" },
+  { tag: tags.escape, color: "var(--palette-6)" },
+
+  // 数値、ブール値、型
+  {
+    tag: [tags.number, tags.bool, tags.null, tags.typeName, tags.className, tags.namespace],
+    color: "var(--palette-3)",
+  },
+
+  // 変数とプロパティ
+  { tag: [tags.variableName, tags.definition(tags.variableName)], color: "var(--palette-fg)" },
+  { tag: [tags.propertyName, tags.definition(tags.propertyName)], color: "var(--palette-4)" },
+
+  // 演算子と句読点
+  { tag: tags.operator, color: "var(--palette-6)" },
+  { tag: tags.punctuation, color: "var(--palette-7)" },
+  { tag: [tags.derefOperator, tags.separator], color: "var(--palette-fg)" },
+
+  // HTML/JSX 属性
+  { tag: tags.attributeName, color: "var(--palette-3)" },
+  { tag: tags.attributeValue, color: "var(--palette-2)" },
+
+  // Markdown マークアップ
+  { tag: tags.heading, color: "var(--palette-4)", fontWeight: "bold" },
+  { tag: tags.emphasis, fontStyle: "italic", color: "var(--palette-5)" },
+  { tag: tags.strong, fontWeight: "bold", color: "var(--palette-3)" },
+  { tag: [tags.link, tags.url], color: "var(--palette-6)", textDecoration: "underline" },
+  { tag: tags.quote, color: "var(--palette-8)", fontStyle: "italic" },
+  { tag: tags.monospace, color: "var(--palette-2)" },
+  { tag: tags.strikethrough, textDecoration: "line-through" },
+
+  // メタと不正
+  { tag: tags.meta, color: "var(--palette-8)" },
+  { tag: tags.invalid, color: "var(--palette-1)" },
+]);
+```
+
+### パレットからシンタックスへのマッピング
+
+| パレットスロット | ANSI カラー | シンタックスカテゴリー |
+| --- | --- | --- |
+| `--palette-1` | Red | 不正なトークン |
+| `--palette-2` | Green | 文字列、属性値、等幅 |
+| `--palette-3` | Yellow | 数値、型、ブール値、属性、太字テキスト |
+| `--palette-4` | Blue | キーワード、プロパティ、見出し |
+| `--palette-5` | Magenta | 関数、タグ、強調 |
+| `--palette-6` | Cyan | 演算子、正規表現、エスケープシーケンス、リンク |
+| `--palette-7` | White | 句読点 |
+| `--palette-8` | Bright black | コメント、引用、メタ |
+| `--palette-15` | Bright white | 行番号 |
+| `--palette-fg` | Foreground | 変数、セパレーター、デリファレンス演算子 |
+
+## 完全なテーマを返す
+
+関数はエディターテーマとシンタックスハイライトの両方を Extension の配列として返します。
+
+```ts
+function createEditorColorTheme(isDark: boolean): Extension[] {
+  const baseTheme = EditorView.theme({ /* ... */ }, { dark: isDark });
+  const highlightStyle = HighlightStyle.define([ /* ... */ ]);
+  return [baseTheme, syntaxHighlighting(highlightStyle)];
+}
+```
+
+## 使い方
+
+```ts
+const extensions = [
+  ...createEditorColorTheme(isDark),
+  // ... other extensions
+];
+```
+
+ランタイムでテーマを切り替えるには、親要素の CSS カスタムプロパティの値を変更するだけです。`HighlightStyle.define()` は `var()` 参照（解決された値ではなく）を使用するため、CodeMirror を再設定せずに CSS を通じて色が更新されます。
+
+<Note>
+
+`EditorView.theme()` に渡される `isDark` パラメーターは、エディター作成時に設定される静的なブール値です。ユーザーがライトテーマとダークテーマを切り替える場合、正しい `isDark` 値でエディターを再作成する必要があります。これは、明示的にテーマ指定されていない要素の CodeMirror のデフォルトフォールバックスタイルにのみ影響します。
+
+</Note>
+
+## ツールチップとパネルのスタイリング
+
+テーマはツールチップ、パネル、折りたたみプレースホルダーもカバーし、視覚的な一貫性を維持します。
+
+```ts
+".cm-tooltip": {
+  border: "1px solid var(--palette-0)",
+  backgroundColor: "var(--palette-bg)",
+},
+".cm-tooltip-autocomplete": {
+  "& > ul > li[aria-selected]": {
+    backgroundColor: "var(--palette-selection)",
+    color: "var(--palette-fg)",
+  },
+},
+".cm-foldPlaceholder": {
+  backgroundColor: "transparent",
+  border: "none",
+  color: "var(--palette-8)",
+},
+```
+
+エディター内のすべての可視サーフェスがパレットの色を使用し、どのカラースキームがアクティブであってもエディターが正しく表示されます。

--- a/src/content/docs-ja/recipes/bracket-colorization.mdx
+++ b/src/content/docs-ja/recipes/bracket-colorization.mdx
@@ -85,6 +85,7 @@ function buildDecorationsFromMarks(
   let rangeIdx = 0;
 
   for (const mark of marks) {
+    // Advance past visible ranges that end before this mark
     while (
       rangeIdx < visibleRanges.length &&
       visibleRanges[rangeIdx].to <= mark.pos

--- a/src/content/docs-ja/recipes/bracket-colorization.mdx
+++ b/src/content/docs-ja/recipes/bracket-colorization.mdx
@@ -1,0 +1,210 @@
+---
+title: ブラケットの色分け
+description: ViewPlugin とスタックベースのペアリング、テーマ対応の CSS カスタムプロパティを使い、ネストの深さに応じてマッチする括弧を色分けする方法。
+sidebar_position: 7
+---
+
+# ブラケットの色分け
+
+このレシピでは、ネストの深さに基づいてマッチする括弧のペアを色分けする CodeMirror Extension を構築します。各深さレベルに固定パレットから異なる色が割り当てられ、パレットはサイクルします。正しくペアになった括弧のみが色付けされ、マッチしない括弧はスタイルなしのままです。
+
+## 概要
+
+この Extension は3つの部分で構成されます。
+
+1. **純粋なスキャナー関数** -- マッチした括弧ペアとそのネスト深さを検出
+2. **ViewPlugin** -- スキャン結果をキャッシュし、表示範囲のデコレーションを構築
+3. **ベーステーマ** -- CSS クラスをカスタムプロパティ経由で色にマッピング
+
+## 括弧ペアのスキャン
+
+スキャナーはスタックベースのアプローチでドキュメントテキストを走査します。開き括弧はスタックにプッシュされ、閉じ括弧は対応するオープナーをポップします。マッチしたペアのみがマークを生成します。
+
+```ts
+const OPEN_BRACKETS = new Set(["(", "[", "{"]);
+const CLOSE_BRACKETS: Record<string, string> = {
+  ")": "(",
+  "]": "[",
+  "}": "{",
+};
+
+interface BracketMark {
+  pos: number;
+  depth: number;
+}
+
+function findBracketPairs(text: string): BracketMark[] {
+  const stack: Array<{ char: string; pos: number; depth: number }> = [];
+  const pairs: Array<[number, number, number]> = [];
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (OPEN_BRACKETS.has(ch)) {
+      stack.push({ char: ch, pos: i, depth: stack.length });
+    } else if (ch in CLOSE_BRACKETS) {
+      const expected = CLOSE_BRACKETS[ch];
+      if (stack.length > 0 && stack[stack.length - 1].char === expected) {
+        const opener = stack.pop()!;
+        pairs.push([opener.pos, i, opener.depth]);
+      }
+    }
+  }
+
+  const marks: BracketMark[] = [];
+  for (const [openPos, closePos, depth] of pairs) {
+    marks.push({ pos: openPos, depth });
+    marks.push({ pos: closePos, depth });
+  }
+  marks.sort((a, b) => a.pos - b.pos);
+  return marks;
+}
+```
+
+設計上の重要なポイント:
+
+- **純粋関数** -- `findBracketPairs` はプレーンな文字列を受け取りデータを返します。CodeMirror に依存せず、ユニットテストが容易です。
+- **マッチしない括弧は静かに無視** -- `)` がスタックのトップとマッチしない場合はスキップされます。スキャン後にスタックに残った未マッチのオープナーも無視されます。
+- **マークは位置順にソート** -- `RangeSetBuilder` がドキュメント順のデコレーションを要求するため、ソートが必要です。
+
+## デコレーションの構築
+
+デコレーションビルダーは、キャッシュされたマークを表示範囲のみにフィルタリングし、画面外コンテンツの不要な DOM 操作を回避します。
+
+```ts
+import { Decoration, DecorationSet, EditorView } from "@codemirror/view";
+import { RangeSetBuilder } from "@codemirror/state";
+
+const COLOR_COUNT = 6;
+
+function buildDecorationsFromMarks(
+  marks: BracketMark[],
+  view: EditorView,
+): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const visibleRanges = view.visibleRanges;
+  let rangeIdx = 0;
+
+  for (const mark of marks) {
+    while (
+      rangeIdx < visibleRanges.length &&
+      visibleRanges[rangeIdx].to <= mark.pos
+    ) {
+      rangeIdx++;
+    }
+
+    if (
+      rangeIdx < visibleRanges.length &&
+      mark.pos >= visibleRanges[rangeIdx].from &&
+      mark.pos < visibleRanges[rangeIdx].to
+    ) {
+      const colorIndex = mark.depth % COLOR_COUNT;
+      builder.add(
+        mark.pos,
+        mark.pos + 1,
+        Decoration.mark({ class: `cm-bracket-${colorIndex}` }),
+      );
+    }
+  }
+
+  return builder.finish();
+}
+```
+
+深さから色へのマッピングは剰余算術 (`depth % COLOR_COUNT`) を使用し、ネストがパレットサイズを超えると色がサイクルします。
+
+## ViewPlugin
+
+プラグインはコンテンツが変更されたときのみドキュメント全体を再スキャンします。ビューポートのみの変更（スクロール）時には、キャッシュされたマークを再利用し、新しい表示範囲にフィルタリングするだけです。
+
+```ts
+import { ViewPlugin, ViewUpdate } from "@codemirror/view";
+
+const bracketColorizePlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    marks: BracketMark[];
+
+    constructor(view: EditorView) {
+      this.marks = findBracketPairs(view.state.doc.toString());
+      this.decorations = buildDecorationsFromMarks(this.marks, view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged) {
+        this.marks = findBracketPairs(update.view.state.doc.toString());
+        this.decorations = buildDecorationsFromMarks(this.marks, update.view);
+      } else if (update.viewportChanged) {
+        this.decorations = buildDecorationsFromMarks(this.marks, update.view);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+```
+
+<Tip>
+
+2段階の更新戦略（`docChanged` vs `viewportChanged`）はパフォーマンスにとって重要です。ドキュメント全体のスキャンは O(n) ですが、キャッシュされたマークを表示範囲にフィルタリングするのはずっと安価で、スクロール中に頻繁に発生します。
+
+</Tip>
+
+## CSS カスタムプロパティによるテーマ対応の色
+
+ベーステーマは合理的なデフォルト値を持つ CSS カスタムプロパティ経由で色を割り当てます。ホストアプリケーションはこれらのプロパティをオーバーライドしてカラースキームに合わせることができます。
+
+```ts
+const bracketColorizeTheme = EditorView.baseTheme({
+  ".cm-bracket-0": { color: "var(--bracket-color-0, #ffd700)" },
+  ".cm-bracket-1": { color: "var(--bracket-color-1, #da70d6)" },
+  ".cm-bracket-2": { color: "var(--bracket-color-2, #179fff)" },
+  ".cm-bracket-3": { color: "var(--bracket-color-3, #ffd700)" },
+  ".cm-bracket-4": { color: "var(--bracket-color-4, #da70d6)" },
+  ".cm-bracket-5": { color: "var(--bracket-color-5, #179fff)" },
+});
+```
+
+`EditorView.baseTheme()` を使用（`EditorView.theme()` ではなく）することで、これらのスタイルは低い優先度となり、アプリケーションのテーマでオーバーライドできます。
+
+デフォルトはゴールド、オーキッド、ブルーの3色でサイクルします。ライトとダークの両方の背景で視覚的に区別しやすい色です。
+
+## Extension のエクスポート
+
+プラグインとテーマを単一の Extension としてバンドルします。
+
+```ts
+import type { Extension } from "@codemirror/state";
+
+function bracketColorize(): Extension {
+  return [bracketColorizePlugin, bracketColorizeTheme];
+}
+```
+
+## 使い方
+
+```ts
+const extensions = [
+  // ... other extensions
+  bracketColorize(),
+];
+```
+
+色をカスタマイズするには、親要素に CSS カスタムプロパティを設定します。
+
+```css
+.my-editor {
+  --bracket-color-0: #e6b422;
+  --bracket-color-1: #c678dd;
+  --bracket-color-2: #61afef;
+  --bracket-color-3: #e6b422;
+  --bracket-color-4: #c678dd;
+  --bracket-color-5: #61afef;
+}
+```
+
+<Note>
+
+このアプローチは構文木ではなく生のドキュメントテキストをスキャンします。Markdown やプレーンテキストでは問題なく動作しますが、文字列リテラルやコメント内の括弧も対象になります。言語を考慮したブラケットカラーライザーを作る場合は、`syntaxTree(state)` を使ってパーサーが識別した括弧トークンのみを走査します。
+
+</Note>

--- a/src/content/docs-ja/recipes/display-scale-integration.mdx
+++ b/src/content/docs-ja/recipes/display-scale-integration.mdx
@@ -1,0 +1,140 @@
+---
+title: 表示スケールの統合
+description: JavaScript でスケーリングされた値を計算し、EditorView.theme() で適用することで、CodeMirror をグローバルな表示スケール係数に対応させる方法。
+sidebar_position: 12
+---
+
+# 表示スケールの統合
+
+このレシピでは、CodeMirror エディターをグローバルな表示スケール係数に対応させる方法を示します。表示スケールは、エディターのフォントサイズとパディングを均一にスケーリングする乗数（例: 1.0, 1.25, 1.5）で、ユーザーがブラウザのズームレベルとは独立してエディターを拡大縮小できるようにします。
+
+## パターン
+
+このアプローチは、JavaScript でスケーリングされたピクセル値を計算し、`EditorView.theme()` で適用します。これはエディター作成時に行われ、スケール係数が変更されるとエディターが再作成されます。
+
+```ts
+import { EditorView } from "@codemirror/view";
+
+const settings = {
+  fontSize: 14,
+  fontFamily: "Menlo",
+  lineHeight: 1.6,
+  paddingHorizontal: 16,
+  paddingVertical: 12,
+};
+
+const displayScale = 1.25;
+
+const scaledFontSize = settings.fontSize * displayScale;
+const scaledPaddingH = settings.paddingHorizontal * displayScale;
+const scaledPaddingV = settings.paddingVertical * displayScale;
+
+const editorTheme = EditorView.theme({
+  ".cm-scroller": {
+    fontFamily: `"${settings.fontFamily}", monospace`,
+    fontSize: `${scaledFontSize}px`,
+    lineHeight: String(settings.lineHeight),
+  },
+  ".cm-content": {
+    padding: `${scaledPaddingV}px 0`,
+  },
+  ".cm-line": {
+    paddingLeft: `${scaledPaddingH}px`,
+    paddingRight: `${scaledPaddingH}px`,
+  },
+});
+```
+
+## スケーリングされるもの
+
+| プロパティ | 基本値 | 1.25x での値 |
+| --- | --- | --- |
+| フォントサイズ | 14px | 17.5px |
+| 水平パディング | 16px | 20px |
+| 垂直パディング | 12px | 15px |
+
+行の高さは単位なしの比率（例: 1.6）であり、フォントサイズに対して相対的なため、スケーリングは不要です。フォントサイズに応じて自動的に調整されます。
+
+## なぜ CSS ではなく JavaScript でスケーリングするのか？
+
+代替アプローチとして、CSS の `transform: scale()` や `calc()` を使った CSS カスタムプロパティ（`--display-scale`）があります。しかし、JavaScript と `EditorView.theme()` によるスケーリングには利点があります。
+
+- **ピクセル精度の値** -- CodeMirror はカーソル位置決め、行高さの計算、ビューポート測定に正確なフォントサイズが必要です。CSS transform はサブピクセルレンダリングの問題を引き起こす可能性があります。
+- **レイアウトの混乱なし** -- CSS `transform: scale()` は要素のレイアウトサイズを変更しないため、CodeMirror のスクロール計算が壊れます。
+- **ガターの配置** -- 行番号が表示される場合、ガターのパディングもスケーリングする必要があります。計算された値を使えば簡単です。
+
+```ts
+const themeRules: Record<string, Record<string, string>> = {
+  ".cm-scroller": {
+    fontFamily: `"${settings.fontFamily}", monospace`,
+    fontSize: `${scaledFontSize}px`,
+    lineHeight: String(settings.lineHeight),
+  },
+  ".cm-content": {
+    padding: `${scaledPaddingV}px 0`,
+  },
+  ".cm-line": {
+    paddingLeft: `${scaledPaddingH}px`,
+    paddingRight: `${scaledPaddingH}px`,
+  },
+};
+
+// 行番号が表示される場合はガターのパディングもスケーリング
+if (showLineNumbers) {
+  themeRules[".cm-gutters"] = {
+    paddingTop: `${scaledPaddingV}px`,
+  };
+}
+
+const editorTheme = EditorView.theme(themeRules);
+```
+
+## CSS カスタムプロパティとの統合
+
+アプリケーションの他の部分（CodeMirror の外側）はスケーリングに CSS カスタムプロパティを使用する場合があります。
+
+```css
+:root {
+  --display-scale: 1.25;
+}
+
+.sidebar {
+  font-size: calc(13px * var(--display-scale));
+}
+```
+
+CodeMirror はこの CSS プロパティを直接使用しません。代わりに、JavaScript レイヤーが設定オブジェクトから同じスケール値を読み取り、ピクセル値を計算します。これにより、UI の他の部分が CSS アプローチを使用しながら、CodeMirror の内部測定値は正確に保たれます。
+
+## 再作成 vs 再設定
+
+このパターンでは、表示スケールが変更されるとエディターが再作成されます。`EditorView.theme()` は作成時にスコープされた CSS ルールを生成し、それらはその場で更新できないため、これが最もシンプルなアプローチです。
+
+```ts
+// React hook の例
+useEffect(() => {
+  const editorTheme = EditorView.theme({
+    ".cm-scroller": {
+      fontSize: `${settings.fontSize * displayScale}px`,
+    },
+  });
+
+  const view = new EditorView({
+    state: EditorState.create({ doc: content, extensions: [editorTheme] }),
+    parent: containerRef.current,
+  });
+
+  return () => view.destroy();
+}, [settings, displayScale]);
+```
+
+<Note>
+
+表示スケールの変更時にエディターを再作成するのは適切です。これはまれな操作（設定でユーザーが調整し、アクティブなタイピング中ではない）であり、`EditorView` の破棄と再作成のコストは、動的なテーマルール更新の複雑さに比べて低いためです。
+
+</Note>
+
+<Tip>
+
+エディターを再作成する際は、ドキュメントの内容とスクロール位置を保持してください。現在の内容を初期 `doc` として渡し、新しいビューが作成された後に `scrollDOM.scrollTop` を復元します。
+
+</Tip>

--- a/src/content/docs-ja/recipes/indent-guides.mdx
+++ b/src/content/docs-ja/recipes/indent-guides.mdx
@@ -1,0 +1,204 @@
+---
+title: インデントガイド
+description: ラインデコレーション、CSS カスタムプロパティ、繰り返しリニアグラディエントを使用して、CodeMirror に垂直インデントガイド線を描画する方法。
+sidebar_position: 8
+---
+
+# インデントガイド
+
+このレシピでは、各インデントレベルに垂直インデントガイド線を描画する CodeMirror Extension を構築します。ガイドは CSS のみで描画され、Canvas や SVG は使用しません。擬似要素上の繰り返しリニアグラディエントを使用します。
+
+## 概要
+
+アプローチは以下の通りです。
+
+1. 表示されている各行で、インデントレベル（先頭のスペースまたはタブの数）を数える
+2. CSS カスタムプロパティ `--indent-level` にレベル数を設定したラインデコレーションを追加
+3. `::before` 擬似要素が繰り返しグラディエントで垂直線を描画
+
+## インデントの計測
+
+インデントカウンターはスペースとタブの両方を固定単位幅に基づく統一レベルに変換します。Markdown ではネストされたリストに2スペースインデントが慣例です。
+
+```ts
+const INDENT_UNIT = 2;
+const MAX_INDENT_LEVEL = 10;
+
+function countIndentLevel(line: string): number {
+  let spaces = 0;
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] === " ") {
+      spaces++;
+    } else if (line[i] === "\t") {
+      spaces += INDENT_UNIT;
+    } else {
+      break;
+    }
+  }
+  // 空白のみの行はスキップ -- 空行にはガイドを表示しない
+  if (spaces >= line.length) return 0;
+  return Math.min(Math.floor(spaces / INDENT_UNIT), MAX_INDENT_LEVEL);
+}
+```
+
+<Note>
+
+空白のみの行は 0 を返し、空行にガイドが描画されるのを防ぎます。これにより、ドキュメントの空の領域に煩わしい垂直線が表示されるのを回避できます。`MAX_INDENT_LEVEL` はデコレーション数を制限し、異常な入力から保護します。
+
+</Note>
+
+## ラインデコレーションの構築
+
+インデントのある各表示行に対して、ラインデコレーションが `--indent-level` カスタムプロパティを設定します。CSS テーマはこの値を使ってグラディエント領域の幅を決定します。
+
+```ts
+import {
+  ViewPlugin,
+  Decoration,
+  DecorationSet,
+  EditorView,
+  ViewUpdate,
+} from "@codemirror/view";
+import { RangeSetBuilder } from "@codemirror/state";
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+
+  for (const { from, to } of view.visibleRanges) {
+    let pos = from;
+    while (pos <= to) {
+      const line = view.state.doc.lineAt(pos);
+      const level = countIndentLevel(line.text);
+
+      if (level > 0) {
+        builder.add(
+          line.from,
+          line.from,
+          Decoration.line({
+            attributes: {
+              class: "cm-indent-guides",
+              style: `--indent-level: ${level}`,
+            },
+          }),
+        );
+      }
+
+      pos = line.to + 1;
+    }
+  }
+
+  return builder.finish();
+}
+```
+
+## ViewPlugin
+
+プラグインはドキュメント変更とビューポートスクロールでデコレーションを再構築します。
+
+```ts
+const indentGuidesPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.viewportChanged) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+```
+
+## CSS テーマ: 繰り返しグラディエントテクニック
+
+テーマは `::before` 擬似要素と繰り返しリニアグラディエントを使用してガイド線を描画します。各「カラム」は `2ch` 幅（`INDENT_UNIT` に対応）で、左端に 1px の線があります。
+
+```ts
+const indentGuidesTheme = EditorView.baseTheme({
+  ".cm-indent-guides": {
+    position: "relative",
+  },
+  ".cm-indent-guides::before": {
+    content: '""',
+    position: "absolute",
+    top: "0",
+    bottom: "0",
+    left: "calc(-1 * var(--cm-hang, 0px))",
+    width: "calc(2ch * var(--indent-level, 0))",
+    paddingLeft: "inherit",
+    backgroundImage: [
+      "repeating-linear-gradient(to right,",
+      "color-mix(in oklch, var(--palette-fg) 12%, transparent) 0px,",
+      "color-mix(in oklch, var(--palette-fg) 12%, transparent) 1px,",
+      "transparent 1px,",
+      "transparent 2ch)",
+    ].join(" "),
+    backgroundOrigin: "content-box",
+    backgroundRepeat: "no-repeat",
+    pointerEvents: "none",
+  },
+});
+```
+
+仕組み:
+
+- **`width: calc(2ch * var(--indent-level, 0))`** -- 擬似要素はすべてのインデントカラムをカバーするのに十分な幅
+- **`repeating-linear-gradient`** -- `2ch` ごとに 1px の垂直線を描画し、インデントレベルごとに1本のガイドを作成
+- **`color-mix(in oklch, var(--palette-fg) 12%, transparent)`** -- 前景色を 12% の不透明度でミックスし、ガイドを控えめに表示。ライトテーマとダークテーマに自動的に適応
+- **`backgroundOrigin: content-box`** と `paddingLeft: inherit` -- グラディエントがエディターの水平パディングの後から開始
+- **`left: calc(-1 * var(--cm-hang, 0px))`** -- リストハンギングインデント Extension によるマージンシフトを補正するために擬似要素をオフセット（[Markdown リスト処理](/docs-ja/recipes/markdown-list-handling/)を参照）
+- **`pointerEvents: none`** -- 擬似要素がクリックを妨げないように設定
+
+<Tip>
+
+`ch` 単位は現在のフォントの `0` 文字の幅に基づきます。等幅フォントではうまく動作しますが、プロポーショナルフォントではガイドの配置は近似値になります。
+
+</Tip>
+
+## Extension のエクスポート
+
+```ts
+import type { Extension } from "@codemirror/state";
+
+function indentGuides(): Extension {
+  return [indentGuidesPlugin, indentGuidesTheme];
+}
+```
+
+## 使い方
+
+```ts
+const extensions = [
+  // ... other extensions
+  indentGuides(),
+];
+```
+
+ガイドの色を変更するには、`color-mix` で使用される CSS カスタムプロパティをオーバーライドします。または、アプリケーションのテーマでグラディエントを置き換えます。
+
+```ts
+const customGuideTheme = EditorView.theme({
+  ".cm-indent-guides::before": {
+    backgroundImage: [
+      "repeating-linear-gradient(to right,",
+      "rgba(128, 128, 128, 0.15) 0px,",
+      "rgba(128, 128, 128, 0.15) 1px,",
+      "transparent 1px,",
+      "transparent 2ch)",
+    ].join(" "),
+  },
+});
+```
+
+<Warning>
+
+ラインデコレーションは `.cm-line` 要素に適用されます。別の Extension（ハンギングインデントなど）も `margin-left` や `text-indent` のラインデコレーションを追加する場合、インデントガイドの擬似要素はそのオフセットを考慮する必要があります。上記の `left: calc(-1 * var(--cm-hang, 0px))` パターンは、ハンギングインデント Extension が設定する CSS カスタムプロパティを読み取ることでこれに対応しています。
+
+</Warning>

--- a/src/content/docs-ja/recipes/markdown-list-handling.mdx
+++ b/src/content/docs-ja/recipes/markdown-list-handling.mdx
@@ -1,0 +1,277 @@
+---
+title: Markdown リスト処理
+description: Markdown リスト向けの2つの補完的な Extension -- Enter でのリストマーカー自動継続と、構文木解析による折り返し行のハンギングインデント。
+sidebar_position: 11
+---
+
+# Markdown リスト処理
+
+このレシピでは、Markdown リスト向けの2つの補完的な CodeMirror Extension を解説します。
+
+1. **リスト継続** -- Enter を押したときにリストマーカーを自動継続、番号の自動インクリメント、空のリストアイテムの削除
+2. **ハンギングインデント** -- 折り返し行をリストマーカーの後のコンテンツに揃える
+
+これらの Extension を組み合わせることで、Obsidian のような Markdown リスト編集体験を実現します。
+
+## なぜビルトインではなくカスタムなのか？
+
+CodeMirror の `@codemirror/lang-markdown` は基本的なリスト継続を処理する `insertNewlineContinueMarkup` を提供しています。しかし、カスタム実装により以下のより細かい制御が可能になります。
+
+- **チェックボックスの継続** -- タスクリストを継続する際に未チェックの `[ ]` チェックボックスを挿入
+- **カーソル末尾の要件** -- 行末にカーソルがある場合のみトリガーし、行の途中ではトリガーしない
+- **空アイテムの動作** -- リストアイテムにコンテンツがない場合、プレフィックスだけでなく行全体をクリア
+
+ハンギングインデント Extension は完全にカスタムで、CodeMirror にはビルトインの同等機能がありません。
+
+## パート 1: リスト継続
+
+### 正規表現によるリスト検出
+
+この Extension は行頭のリストマーカーを検出する正規表現を使用します。
+
+```ts
+const listMarkerRe = /^(\s*)([-*+]|\d+\.)\s(\[[ xX]\]\s)?/;
+```
+
+これがマッチするもの:
+
+- オプションの先頭空白（`\s*`）
+- リストマーカー: `-`, `*`, `+`, または数字の後の `.`
+- マーカー後の必須スペース
+- オプションのチェックボックス（`[ ]`, `[x]`, `[X]`）と末尾のスペース
+
+### 次のマーカーの計算
+
+```ts
+function getNextListMarker(
+  lineText: string,
+): { prefix: string; isEmpty: boolean } | null {
+  const match = lineText.match(listMarkerRe);
+  if (!match) return null;
+
+  const [fullMatch, indent, marker, checkbox] = match;
+  const textAfterMarker = lineText.slice(fullMatch.length);
+  const isEmpty = textAfterMarker.trim() === "";
+
+  let nextMarker = marker;
+  if (/^\d+\./.test(marker)) {
+    const num = parseInt(marker, 10);
+    nextMarker = `${num + 1}.`;
+  }
+
+  const nextCheckbox = checkbox ? "[ ] " : "";
+  const prefix = `${indent}${nextMarker} ${nextCheckbox}`;
+
+  return { prefix, isEmpty };
+}
+```
+
+番号付きリストは自動インクリメントされます。現在の行が `3.` で始まる場合、次の行は `4.` になります。チェックボックスリストは未チェックの `[ ]` で継続します。
+
+### キーマップハンドラー
+
+```ts
+import { EditorView, keymap } from "@codemirror/view";
+
+function handleEnterInList(view: EditorView): boolean {
+  const { state } = view;
+  const { from, to } = state.selection.main;
+
+  // 単一カーソルのみ処理（範囲選択なし）
+  if (from !== to) return false;
+
+  const line = state.doc.lineAt(from);
+
+  // カーソルが行末にある場合のみトリガー
+  if (from !== line.to) return false;
+
+  const result = getNextListMarker(line.text);
+  if (!result) return false;
+
+  // 空のリストアイテム -- マーカー行を削除してリストを終了
+  if (result.isEmpty) {
+    view.dispatch({
+      changes: { from: line.from, to: line.to, insert: "" },
+    });
+    return true;
+  }
+
+  // 継続されたマーカーで新しい行を挿入
+  const newLine = `\n${result.prefix}`;
+  view.dispatch({
+    changes: { from, to: from, insert: newLine },
+    selection: { anchor: from + newLine.length },
+    scrollIntoView: true,
+  });
+  return true;
+}
+
+function markdownListIndent() {
+  return keymap.of([
+    { key: "Enter", run: handleEnterInList },
+  ]);
+}
+```
+
+<Tip>
+
+ハンドラーは適用されない場合（非リスト行、カーソルが末尾にない、アクティブな選択がある場合）に `false` を返します。これにより、Enter キーの他のキーバインディングがイベントを処理できます。`true` を返すと伝播が停止します。
+
+</Tip>
+
+### 動作まとめ
+
+| 現在の行 | アクション |
+| --- | --- |
+| `- Item text` | `\n- ` を挿入し、マーカー後にカーソルを配置 |
+| `3. Item text` | `\n4. ` を挿入（自動インクリメント） |
+| `- [ ] Task` | `\n- [ ] ` を挿入（未チェックのチェックボックス） |
+| `- `（空アイテム） | 行全体をクリアし、リストを終了 |
+
+## パート 2: ハンギングインデント
+
+長いリストアイテムが次の視覚行に折り返される場合、デフォルトの動作では継続テキストがリストマーカーと左揃えになります。ハンギングインデントはマーカーの*後の*コンテンツに揃えます。
+
+```
+ハンギングインデントなし:
+- これは次の視覚行に折り返される長いリスト
+アイテムです
+
+ハンギングインデントあり:
+- これは次の視覚行に折り返される長いリスト
+  アイテムです
+```
+
+### 構文木を使ったマーカー幅の計測
+
+この Extension は Lezer 構文木を使用して `ListItem` ノードを特定し、マーカープレフィックスの幅を計測します。
+
+```ts
+import { syntaxTree } from "@codemirror/language";
+import { countColumn } from "@codemirror/state";
+
+const listPrefixRe =
+  /^([ \t]*)([-*+]|\d+\.)( {1,4}\[[ xX]\])? {1,4}/;
+
+function getMarkerWidth(text: string, tabSize: number): number {
+  const m = listPrefixRe.exec(text);
+  if (!m) return 0;
+  const markerOnly = m[0].slice(m[1].length);
+  return countColumn(markerOnly, tabSize);
+}
+```
+
+マーカー幅は CodeMirror の state モジュールの `countColumn` を使用して計測され、タブ文字を正しく考慮します。先頭の空白は除外されます。CodeMirror が通常のインデントで処理するためです。
+
+### デコレーションの構築
+
+```ts
+import {
+  ViewPlugin,
+  Decoration,
+  DecorationSet,
+  EditorView,
+  ViewUpdate,
+} from "@codemirror/view";
+import { RangeSetBuilder } from "@codemirror/state";
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const tree = syntaxTree(view.state);
+  const seen = new Set<number>();
+
+  for (const { from, to } of view.visibleRanges) {
+    tree.iterate({
+      from,
+      to,
+      enter(node) {
+        if (node.name !== "ListItem") return;
+
+        const line = view.state.doc.lineAt(node.from);
+        if (seen.has(line.from)) return;
+        seen.add(line.from);
+
+        const cols = getMarkerWidth(line.text, view.state.tabSize);
+        if (cols <= 0) return;
+
+        builder.add(
+          line.from,
+          line.from,
+          Decoration.line({
+            attributes: {
+              class: "cm-list-hanging-indent",
+              style: `--cm-hang: ${cols}ch`,
+            },
+          }),
+        );
+      },
+    });
+  }
+
+  return builder.finish();
+}
+```
+
+`seen` セットは、構文木が同じ行から始まる複数の `ListItem` ノードを返す場合の重複デコレーションを防ぎます。
+
+### CSS テクニック
+
+ハンギングインデントは `margin-left` と `text-indent` を駆動する CSS カスタムプロパティ `--cm-hang` で実現されます。
+
+```ts
+const listHangingIndentTheme = EditorView.baseTheme({
+  ".cm-list-hanging-indent": {
+    marginLeft: "var(--cm-hang)",
+    textIndent: "calc(-1 * var(--cm-hang))",
+  },
+});
+```
+
+仕組み:
+
+- `margin-left: var(--cm-hang)` は行全体（折り返しテキストを含む）を右にシフト
+- `text-indent: calc(-1 * var(--cm-hang))` は最初の行を元の位置に引き戻す
+
+結果: 最初の行は通常の位置から始まり、折り返し行はマーカーの後のコンテンツに揃えてインデントされます。
+
+<Warning>
+
+`ch` 単位は等幅フォントを前提としています。プロポーショナルフォントでは文字幅が異なるため、配置は近似値になります。プロポーショナルフォントで正確な配置を得るには、プレフィックステキストの実際のピクセル幅を計測する必要があります。
+
+</Warning>
+
+### 構文木の更新
+
+プラグインは `docChanged` と `viewportChanged` だけでなく、構文木自体が変更された場合にもデコレーションを再構築します。
+
+```ts
+update(update: ViewUpdate) {
+  if (
+    update.docChanged ||
+    update.viewportChanged ||
+    syntaxTree(update.startState) !== syntaxTree(update.state)
+  ) {
+    this.decorations = buildDecorations(update.view);
+  }
+}
+```
+
+これは、Lezer パーサーがインクリメンタルに実行され、ドキュメント変更後にツリーが非同期的に更新されるケースを処理します。
+
+## 両方の Extension を一緒に使用する
+
+ハンギングインデント Extension が使用する `margin-left` / `text-indent` アプローチは、インデントガイド Extension（[インデントガイド](/docs-ja/recipes/indent-guides/)を参照）にも影響します。インデントガイドは擬似要素に `left: calc(-1 * var(--cm-hang, 0px))` を使用してマージンシフトを補正し、リスト行と非リスト行の両方でガイドが正しく配置されるようにします。
+
+```ts
+const extensions = [
+  // ... other extensions
+  markdownListIndent(),
+  listHangingIndent(),
+];
+```
+
+<Note>
+
+ハンギングインデントに `margin-left`（`padding-left` ではなく）を使用するのは意図的です。CodeMirror のテーマは `.cm-line` に水平パディング用の `padding-left` を設定します。`margin-left` を使用することで、そのパディングをオーバーライドせず、両方が共存できます。
+
+</Note>

--- a/src/content/docs-ja/recipes/scrollbar-cursor-indicator.mdx
+++ b/src/content/docs-ja/recipes/scrollbar-cursor-indicator.mdx
@@ -1,0 +1,193 @@
+---
+title: スクロールバーのカーソルインジケーター
+description: ViewPlugin と DOM 操作を使用して、カーソル位置をスクロールバートラック上の細い水平線として表示する方法。
+sidebar_position: 10
+---
+
+# スクロールバーのカーソルインジケーター
+
+このレシピでは、VS Code のミニマップカーソルインジケーターのように、カーソルの位置をスクロールバートラック上の細い水平線として表示する CodeMirror Extension を構築します。長いドキュメントでの現在位置を素早く視覚的に確認できます。
+
+## 概要
+
+この Extension は、エディターの DOM 内に絶対位置で配置された小さな `<div>` 要素を作成します。この要素は、ドキュメント内のカーソルの相対位置に基づいて垂直方向に配置されます。選択変更、ドキュメント変更、ジオメトリ変更時に更新されます。
+
+## 実装
+
+```ts
+import { EditorView, ViewPlugin, ViewUpdate } from "@codemirror/view";
+
+const SCROLLBAR_WIDTH = "14px";
+
+function scrollbarCursorIndicator() {
+  return ViewPlugin.fromClass(
+    class {
+      private indicator: HTMLDivElement;
+      private pendingFrame = 0;
+      private focused: boolean;
+      private readonly onFocus: () => void;
+      private readonly onBlur: () => void;
+
+      constructor(private view: EditorView) {
+        this.indicator = document.createElement("div");
+        Object.assign(this.indicator.style, {
+          position: "absolute",
+          right: "0",
+          width: SCROLLBAR_WIDTH,
+          height: "2px",
+          pointerEvents: "none",
+          zIndex: "10",
+          background: "var(--palette-cursor)",
+        });
+        view.dom.appendChild(this.indicator);
+
+        this.focused = view.hasFocus;
+        this.updatePosition();
+
+        this.onFocus = () => {
+          this.focused = true;
+          this.updatePosition();
+        };
+        this.onBlur = () => {
+          this.focused = false;
+          this.indicator.style.display = "none";
+        };
+        view.dom.addEventListener("focusin", this.onFocus);
+        view.dom.addEventListener("focusout", this.onBlur);
+      }
+
+      update(update: ViewUpdate) {
+        if (
+          update.selectionSet ||
+          update.docChanged ||
+          update.geometryChanged
+        ) {
+          if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+          this.pendingFrame = requestAnimationFrame(() => {
+            this.pendingFrame = 0;
+            this.updatePosition();
+          });
+        }
+      }
+
+      private updatePosition() {
+        if (!this.focused) {
+          this.indicator.style.display = "none";
+          return;
+        }
+
+        const { scrollDOM, state } = this.view;
+        const { scrollHeight, clientHeight } = scrollDOM;
+
+        // コンテンツがスクロールしない場合は非表示
+        if (scrollHeight <= clientHeight) {
+          this.indicator.style.display = "none";
+          return;
+        }
+        this.indicator.style.display = "";
+
+        const head = state.selection.main.head;
+        const block = this.view.lineBlockAt(head);
+        const contentH = this.view.contentHeight;
+        const ratio = contentH > 0 ? block.top / contentH : 0;
+        const scrollerTop = scrollDOM.offsetTop;
+        const trackHeight = clientHeight;
+        this.indicator.style.top = `${scrollerTop + ratio * trackHeight}px`;
+      }
+
+      destroy() {
+        if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+        this.view.dom.removeEventListener("focusin", this.onFocus);
+        this.view.dom.removeEventListener("focusout", this.onBlur);
+        this.indicator.remove();
+      }
+    },
+  );
+}
+```
+
+## 主要な設計判断
+
+### 位置の計算
+
+インジケーターの垂直位置は、カーソルの行位置とコンテンツ全体の高さの比率として計算されます。
+
+```
+ratio = lineBlock.top / contentHeight
+indicatorTop = scrollerTop + ratio * trackHeight
+```
+
+`lineBlockAt(head)` はカーソル位置の視覚的な行ブロックを返し、コンテンツ上端からのピクセルオフセットを提供します。`contentHeight` で割ることで、スクロールバートラックにマッピングされる 0-1 の比率が得られます。
+
+<Note>
+
+この Extension は `scrollHeight`（`scrollPastEnd()` のパディングを含む場合がある）ではなく、`contentHeight`（実際のドキュメントコンテンツの高さ）を使用します。これにより、エディターが最後の行の後に追加のスクロール可能なスペースを持つ場合に、インジケーターが不自然に低い位置に押し下げられるのを防ぎます。
+
+</Note>
+
+### フォーカス対応の可視性
+
+インジケーターはエディターがフォーカスを持っている場合のみ表示されます。分割ペインエディターでは、複数の CodeMirror インスタンスが同時に表示される場合があります。フォーカス対応がないと、各ペインが独自のインジケーターを表示し、視覚的な混乱を引き起こします。
+
+```ts
+this.onFocus = () => {
+  this.focused = true;
+  this.updatePosition();
+};
+this.onBlur = () => {
+  this.focused = false;
+  this.indicator.style.display = "none";
+};
+```
+
+プラグインは `true` をデフォルトにするのではなく、`view.hasFocus` から `this.focused` を初期化します。これにより、フォーカスを受け取らずに作成されたエディター（新しく開いた分割ペインなど）のケースを処理します。
+
+### DOM アプローチ vs デコレーション
+
+この Extension は CodeMirror のデコレーションではなく、直接の DOM 操作（`view.dom` への `<div>` の追加）を使用します。これは、インジケーターがドキュメントコンテンツではなくスクロールバーに対して相対的に配置されるためです。デコレーションはドキュメント範囲にアノテーションを付けるために設計されており、スクロールバートラック上のオーバーレイには使用できません。
+
+### requestAnimationFrame
+
+位置の更新は `requestAnimationFrame` でバッチ処理され、複数のイベントが短時間に連続して発火した場合（高速タイピングなど）のレイアウトスラッシングを回避します。
+
+## クリーンアップ
+
+`destroy` メソッドはインジケーター要素を削除し、ペンディングのアニメーションフレームをキャンセルし、イベントリスナーを削除します。
+
+```ts
+destroy() {
+  if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+  this.view.dom.removeEventListener("focusin", this.onFocus);
+  this.view.dom.removeEventListener("focusout", this.onBlur);
+  this.indicator.remove();
+}
+```
+
+<Warning>
+
+`destroy` メソッドで必ずイベントリスナーを削除してください。クリーンアップしないと、Extension が再設定されたりエディターが再作成されたりした場合にリスナーが蓄積されます。
+
+</Warning>
+
+## 使い方
+
+```ts
+const extensions = [
+  // ... other extensions
+  scrollbarCursorIndicator(),
+];
+```
+
+インジケーターの色を変更するには、CSS カスタムプロパティを設定します。
+
+```css
+.my-editor {
+  --palette-cursor: #528bff;
+}
+```
+
+または、インジケータースタイルの `background` 値を固定色に変更します。
+
+```ts
+background: "rgba(82, 139, 255, 0.8)",
+```

--- a/src/content/docs-ja/recipes/settings-driven-editor.mdx
+++ b/src/content/docs-ja/recipes/settings-driven-editor.mdx
@@ -1,0 +1,254 @@
+---
+title: 設定駆動型エディター構成
+description: アプリケーション設定オブジェクトから CodeMirror を完全に設定し、ランタイム再設定にはコンパートメントを、バリデーションには共有スキーマを使用するパターン。
+sidebar_position: 13
+---
+
+# 設定駆動型エディター構成
+
+このレシピでは、アプリケーション設定オブジェクトから CodeMirror エディターを完全に設定するパターンを解説します。すべてのエディター動作（フォント、インデント、機能トグル）が単一の設定ソースから供給され、共有スキーマによってバリデーションされます。
+
+## 設定オブジェクト
+
+エディター設定は型付きフィールドを持つプレーンオブジェクトです。
+
+```ts
+interface EditorSettings {
+  fontFamily: string;
+  fontSize: number;
+  lineHeight: number;
+  paddingHorizontal: number;
+  paddingVertical: number;
+  indentType: "tab" | "spaces";
+  indentSize: number;
+  vimMode: boolean;
+  typewriterScrolling: boolean;
+  showIndentGuides: boolean;
+  bracketColorization: boolean;
+  markdownListIndent: boolean;
+  listHangingIndent: boolean;
+  showStatusBar: boolean;
+}
+```
+
+デフォルト値は共有パッケージで定義され、フロントエンドと設定バリデーションロジックの両方が同じデフォルトを使用します。
+
+```ts
+const defaultEditorSettings: EditorSettings = {
+  fontFamily: "Menlo",
+  fontSize: 14,
+  lineHeight: 1.6,
+  paddingHorizontal: 16,
+  paddingVertical: 12,
+  indentType: "spaces",
+  indentSize: 2,
+  vimMode: false,
+  typewriterScrolling: false,
+  showIndentGuides: true,
+  bracketColorization: true,
+  markdownListIndent: true,
+  listHangingIndent: true,
+  showStatusBar: true,
+};
+```
+
+## 設定から Extension へのマッピング
+
+各設定は1つ以上の CodeMirror Extension または設定オプションにマッピングされます。Extension の配列は現在の設定に基づいて動的に構築されます。
+
+```ts
+import { EditorState, Compartment } from "@codemirror/state";
+import { EditorView, keymap, lineNumbers, scrollPastEnd } from "@codemirror/view";
+import { indentUnit } from "@codemirror/language";
+import { indentWithTab } from "@codemirror/commands";
+import { vim } from "@replit/codemirror-vim";
+
+function buildExtensions(settings: EditorSettings) {
+  return [
+    // Vim モード（条件付き）
+    ...(settings.vimMode ? [vim()] : []),
+
+    // テーマによるフォントとレイアウト
+    EditorView.theme({
+      ".cm-scroller": {
+        fontFamily: `"${settings.fontFamily}", monospace`,
+        fontSize: `${settings.fontSize}px`,
+        lineHeight: String(settings.lineHeight),
+      },
+      ".cm-content": {
+        padding: `${settings.paddingVertical}px 0`,
+      },
+      ".cm-line": {
+        paddingLeft: `${settings.paddingHorizontal}px`,
+        paddingRight: `${settings.paddingHorizontal}px`,
+      },
+    }),
+
+    // インデント
+    EditorState.tabSize.of(settings.indentSize),
+    indentUnit.of(
+      settings.indentType === "tab"
+        ? "\t"
+        : " ".repeat(settings.indentSize),
+    ),
+    keymap.of([indentWithTab]),
+
+    // 機能トグル
+    ...(settings.markdownListIndent ? [markdownListIndent()] : []),
+    ...(settings.listHangingIndent ? [listHangingIndent()] : []),
+    ...(settings.showIndentGuides ? [indentGuides()] : []),
+    ...(settings.typewriterScrolling ? [typewriterScrolling()] : []),
+    ...(settings.bracketColorization ? [bracketColorize()] : []),
+
+    scrollPastEnd(),
+  ];
+}
+```
+
+### フォント設定
+
+フォントファミリー、サイズ、行の高さ、パディングはすべて `EditorView.theme()` で適用されます。CodeMirror はカーソル位置決め、行高さの計算、ビューポート測定に正確なピクセル値が必要なため、これらの値を CSS カスタムプロパティとして設定することはできません。
+
+### インデント
+
+2つの CodeMirror プリミティブがインデントを制御します。
+
+- `EditorState.tabSize.of(n)` -- タブ文字の視覚的な幅を設定
+- `indentUnit.of(unit)` -- ユーザーが Tab を押したときに挿入される内容を設定。`"\t"` 文字列はタブ文字を挿入し、スペースの文字列はそのスペース数を挿入
+
+### 機能トグル
+
+オプションの Extension は三項演算子とスプレッド演算子を使って条件付きで含めます。
+
+```ts
+...(settings.typewriterScrolling ? [typewriterScrolling()] : []),
+```
+
+このパターンは明確で、ネストされた if-else ブロックを回避します。各トグルは対応する Extension を追加または省略します。
+
+## ランタイム再設定のためのコンパートメント
+
+一部の設定はエディターを再作成せずにランタイムで変更できます。CodeMirror の [Compartment](/docs-ja/extensions/compartments/) がこれを可能にします。
+
+```ts
+const readOnlyCompartment = new Compartment();
+
+const extensions = [
+  readOnlyCompartment.of(EditorState.readOnly.of(false)),
+  // ... other extensions
+];
+
+// 後で readOnly をトグル:
+view.dispatch({
+  effects: readOnlyCompartment.reconfigure(EditorState.readOnly.of(true)),
+});
+```
+
+コンパートメントは頻繁に変更される設定（分割ペインでの読み取り専用モードなど）に便利です。まれにしか変更されない設定（フォントサイズや Vim モードなど）では、エディターの再作成のほうがシンプルで、多数のコンパートメントを管理する複雑さを回避できます。
+
+<Tip>
+
+実用的なガイドライン: アクティブな編集中に変更される設定（読み取り専用トグル、行の折り返し）にはコンパートメントを使用します。設定ダイアログで変更される設定（フォント、インデント、機能トグル）にはエディターを再作成します。CodeMirror は高速な初期化を前提に設計されているため、`EditorView` の再作成コストは低いです。
+
+</Tip>
+
+## バリデーションとデフォルト
+
+共有スキーマパッケージが設定をバリデーションし、デフォルトを適用します。
+
+```ts
+function validateEditorSettings(input: Partial<EditorSettings>): EditorSettings {
+  return {
+    fontFamily: input.fontFamily || defaultEditorSettings.fontFamily,
+    fontSize: clamp(input.fontSize ?? defaultEditorSettings.fontSize, 10, 24),
+    lineHeight: input.lineHeight ?? defaultEditorSettings.lineHeight,
+    paddingHorizontal: clamp(
+      input.paddingHorizontal ?? defaultEditorSettings.paddingHorizontal,
+      0,
+      48,
+    ),
+    paddingVertical: clamp(
+      input.paddingVertical ?? defaultEditorSettings.paddingVertical,
+      0,
+      48,
+    ),
+    indentType: input.indentType === "tab" ? "tab" : "spaces",
+    indentSize: clamp(input.indentSize ?? defaultEditorSettings.indentSize, 1, 8),
+    vimMode: input.vimMode ?? defaultEditorSettings.vimMode,
+    typewriterScrolling: input.typewriterScrolling ?? defaultEditorSettings.typewriterScrolling,
+    showIndentGuides: input.showIndentGuides ?? defaultEditorSettings.showIndentGuides,
+    bracketColorization: input.bracketColorization ?? defaultEditorSettings.bracketColorization,
+    markdownListIndent: input.markdownListIndent ?? defaultEditorSettings.markdownListIndent,
+    listHangingIndent: input.listHangingIndent ?? defaultEditorSettings.listHangingIndent,
+    showStatusBar: input.showStatusBar ?? defaultEditorSettings.showStatusBar,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+```
+
+このバリデーションにより、ユーザーが設定ファイルに何を入力しても、エディターは常に期待される範囲内の安全な値を受け取ります。同じバリデーション関数がバックエンド（ディスクから設定を読み取る際）とフロントエンド（CodeMirror に渡す前）の両方で使用されます。
+
+## React 統合パターン
+
+React アプリケーションでは、設定が変更されると `useEffect` の依存関係を通じてエディターが再作成されます。
+
+```ts
+useEffect(() => {
+  if (!containerRef.current || !settings) return;
+
+  const extensions = buildExtensions(settings);
+  const state = EditorState.create({ doc: content, extensions });
+  const view = new EditorView({ state, parent: containerRef.current });
+
+  return () => view.destroy();
+}, [settings]);
+```
+
+`settings` オブジェクトはメモ化され、実際の値が変更された場合にのみ effect が再実行されます。
+
+```ts
+const settings = useMemo(
+  () => appSettings
+    ? { ...defaultEditorSettings, ...appSettings.editor }
+    : null,
+  [appSettings],
+);
+```
+
+<Note>
+
+エディターが再作成される際は、ドキュメントの内容とスクロール位置を保持する必要があります。`content` プロパティが現在のドキュメントを提供し、スクロール位置は `view.scrollDOM.scrollTop` で保存・復元できます。
+
+</Note>
+
+## 設定 UI
+
+各設定は設定 UI のフォームコントロールに対応します。設定ページは現在の設定とマージされる部分的な更新をディスパッチします。
+
+```ts
+interface EditorSettingsProps {
+  values: EditorSettings;
+  onChange: (values: Partial<EditorSettings>) => void;
+}
+
+// 例: フォントサイズ入力
+<input
+  type="number"
+  min={10}
+  max={24}
+  value={values.fontSize}
+  onChange={(e) => onChange({ fontSize: Number(e.target.value) })}
+/>
+
+// 例: 機能トグル
+<input
+  type="checkbox"
+  checked={values.typewriterScrolling}
+  onChange={(e) => onChange({ typewriterScrolling: e.target.checked })}
+/>
+```
+
+部分更新パターン（`Partial<EditorSettings>`）により、各コントロールは他の設定を知ることなく自分のフィールドのみを更新できます。

--- a/src/content/docs-ja/recipes/typewriter-scrolling.mdx
+++ b/src/content/docs-ja/recipes/typewriter-scrolling.mdx
@@ -1,0 +1,140 @@
+---
+title: タイプライタースクロール
+description: ViewPlugin と requestAnimationFrame、トレランスゾーンを使って、タイピング中にカーソル行をビューポートの中央に保つ方法。
+sidebar_position: 9
+---
+
+# タイプライタースクロール
+
+タイプライタースクロールは、iA Writer や Obsidian のような執筆向けエディターと同様に、ユーザーがタイピングする際にカーソル行をエディタービューポートの垂直中央に保ちます。このレシピでは、CodeMirror Extension として構築する方法を示します。
+
+## 仕組み
+
+この Extension は選択範囲とドキュメントの変更をリッスンする `ViewPlugin` を使用します。カーソルがビューポート中央付近のトレランスゾーンの外に出ると、エディターがスクロールして再度中央に配置します。
+
+```ts
+import { ViewPlugin, ViewUpdate } from "@codemirror/view";
+
+function typewriterScrolling() {
+  return ViewPlugin.fromClass(
+    class {
+      private pendingFrame = 0;
+
+      update(update: ViewUpdate) {
+        if (!update.selectionSet && !update.docChanged) return;
+
+        if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+
+        const view = update.view;
+        const { head } = view.state.selection.main;
+
+        this.pendingFrame = requestAnimationFrame(() => {
+          this.pendingFrame = 0;
+          const coords = view.coordsAtPos(head);
+          if (!coords) return;
+
+          const editorRect = view.dom.getBoundingClientRect();
+          const viewportHeight = editorRect.height;
+          const centerY = editorRect.top + viewportHeight / 2;
+          const cursorY = coords.top;
+
+          // カーソルが中央 1/3 の外にある場合のみスクロール
+          const tolerance = viewportHeight / 6;
+          if (Math.abs(cursorY - centerY) < tolerance) return;
+
+          view.scrollDOM.scrollTo({
+            top: view.scrollDOM.scrollTop + (cursorY - centerY),
+            behavior: "instant",
+          });
+        });
+      }
+
+      destroy() {
+        if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+      }
+    },
+  );
+}
+```
+
+## 主要な設計判断
+
+### requestAnimationFrame
+
+スクロール調整は `update` メソッド内で同期的にではなく、`requestAnimationFrame` 内で実行されます。これによりレイアウトスラッシングを防ぎます -- レイアウトプロパティの読み取り（`coordsAtPos` や `getBoundingClientRect` など）の後にすぐ書き込み（`scrollTo`）を同じ同期フロー内で行うと、ブラウザにレイアウトの再計算を複数回強制する可能性があります。
+
+同じフレーム内で複数の更新が到着した場合、前のペンディングフレームはキャンセルされます。最後の更新のスクロール調整のみが実行されます。
+
+### トレランスゾーン
+
+トレランスゾーンがないと、エディターはすべてのカーソル移動でスクロールし、ガタつく体験になります。トレランスはビューポートの高さの 1/6 に設定されており、カーソルはビューポートの中央 1/3 内ではスクロールをトリガーせずに移動できます。
+
+```
+ +--------------------------+
+ |                          |  <- 上部 1/3（ここでスクロール発生）
+ |                          |
+ +--------------------------+
+ |                          |  <- 中央 1/3（スクロールなし）
+ |       カーソルここOK      |
+ +--------------------------+
+ |                          |  <- 下部 1/3（ここでスクロール発生）
+ |                          |
+ +--------------------------+
+```
+
+### トリガー条件
+
+プラグインは2つの条件に応答します。
+
+- **`update.selectionSet`** -- カーソルが移動した（矢印キー、マウスクリック、検索ジャンプ）
+- **`update.docChanged`** -- ドキュメントが変更された（タイピング、ペースト、アンドゥ）
+
+タイピングはドキュメント変更と選択変更の両方を生成し、クリックは選択のみを変更するため、両方が必要です。
+
+### インスタントスクロール
+
+スクロール動作は `"smooth"` ではなく `"instant"` に設定されています。スムーススクロールは高速タイピング時にアニメーションの遅れが目立ちます。インスタントスクロールは可視的な遅延なくカーソルを中央に保ちます。
+
+<Note>
+
+よりソフトな感触を好む場合は `"instant"` を `"smooth"` に変更できます。ただし、高速なキー入力は複数のスムーススクロールアニメーションをキューに入れ、ビューポートがカーソルに遅れを取る可能性があることに注意してください。
+
+</Note>
+
+## クリーンアップ
+
+`destroy` メソッドはプラグインが削除されるときにペンディングのアニメーションフレームをキャンセルします。これにより、エディターが破棄された後に古いコールバックが実行されるのを防ぎます。
+
+```ts
+destroy() {
+  if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+}
+```
+
+## 使い方
+
+```ts
+const extensions = [
+  // ... other extensions
+  typewriterScrolling(),
+];
+```
+
+<Tip>
+
+タイプライタースクロールは `@codemirror/view` の `scrollPastEnd()` と組み合わせると最適に動作します。これがないと、最後の行の下にコンテンツがないため、最後の行をビューポートの中央にスクロールできません。`scrollPastEnd()` はドキュメントの後に仮想スペースを追加して、これを可能にします。
+
+</Tip>
+
+## トグル可能にする
+
+設定駆動型エディターでは、タイプライタースクロールはエディターを再作成せずにオン/オフできるべきです。一つのアプローチは、Extension を条件付きで含めることです。
+
+```ts
+const extensions = [
+  // ... other extensions
+  ...(settings.typewriterScrolling ? [typewriterScrolling()] : []),
+];
+```
+
+または、ランタイムでの再設定に [Compartment](/docs-ja/extensions/compartments/) を使用します。

--- a/src/content/docs-ja/vim-mode/clipboard.mdx
+++ b/src/content/docs-ja/vim-mode/clipboard.mdx
@@ -224,7 +224,7 @@ function createClipboardRegister() {
   return register;
 }
 
-function setupClipboardIntegration(editorElement: HTMLElement) {
+function setupClipboardIntegration() {
   const controller = Vim.getRegisterController();
   const registers = controller.registers;
   const clipboardRegister = createClipboardRegister();
@@ -265,4 +265,4 @@ function setupClipboardIntegration(editorElement: HTMLElement) {
 }
 ```
 
-EditorView の作成後に `setupClipboardIntegration(view.dom)` を呼び出してください。返されたクリーンアップ関数を保存し、エディター破棄時に呼び出してください。
+EditorView の作成後に `setupClipboardIntegration()` を呼び出してください。返されたクリーンアップ関数を保存し、エディター破棄時に呼び出してください。

--- a/src/content/docs-ja/vim-mode/clipboard.mdx
+++ b/src/content/docs-ja/vim-mode/clipboard.mdx
@@ -106,7 +106,11 @@ controller.unnamedRegister = clipboardRegister;
 
 上記のアプローチの制限として、エディターの外部でコピーされたテキスト（例: 別のアプリケーション）は `p` で自動的に利用できません。内部レジスタはエディター内でヤンクされたテキストしか把握していないためです。
 
-外部クリップボードの内容を処理するには、エディターがフォーカスを得たときに `navigator.clipboard` から読み取ります。
+外部クリップボードの内容を処理するには、エディターまたはウィンドウがフォーカスを得たときに `navigator.clipboard` から読み取ります。
+
+### 標準ブラウザでのアプローチ
+
+標準的なウェブページでは、エディターの `focus` イベントをリッスンします。
 
 ```ts
 view.dom.addEventListener("focus", async () => {
@@ -123,15 +127,55 @@ view.dom.addEventListener("focus", async () => {
 });
 ```
 
+### Tauri / WKWebView: `window.focus` を使用する
+
 <Warning>
 
-`navigator.clipboard.readText()` にはクリップボード読み取り権限が必要です。一部のブラウザでは、ドキュメントがフォーカスされると自動的に権限が付与されます。その他のブラウザでは、ユーザーに権限プロンプトが表示される場合があります。権限が拒否された場合、catch ブロックがエラーを暗黙的に処理します。
+Tauri アプリケーション（macOS WKWebView を使用）では、エディター要素の `focusin` イベントハンドラー内で `navigator.clipboard.readText()` を呼び出すと、ネイティブの macOS「ペースト」編集メニューがトリガーされます。これはテキストカーソル付近にフローティングメニューとして表示されるクリップボード許可プロンプトです。ユーザーがエディターにクリックするたびに表示されるため、ユーザー体験が悪化します。
+
+**`view.dom.addEventListener("focusin", ...)` ではなく `window.addEventListener("focus", ...)` を使用してください。**
 
 </Warning>
 
+`window.focus` イベントは、アプリケーションウィンドウが別のアプリケーションからフォーカスを取り戻した（例: ユーザーが Cmd+Tab で戻った）ときに発火します。これはシステムクリップボードに外部ソースからの新しいコンテンツが含まれている可能性が最も高い瞬間です。
+
+```ts
+const syncHandler = async () => {
+  try {
+    const text = await navigator.clipboard.readText();
+    if (text && clipboardRegister.keyBuffer.join("\n") !== text) {
+      clipboardRegister.keyBuffer = [text];
+      clipboardRegister.linewise = text.endsWith("\n");
+      clipboardRegister.blockwise = false;
+    }
+  } catch {
+    // クリップボード権限が拒否 -- 無視
+  }
+};
+
+window.addEventListener("focus", syncHandler);
+
+// エディター破棄時のクリーンアップ
+function teardown() {
+  window.removeEventListener("focus", syncHandler);
+}
+```
+
+標準アプローチとの主な違い:
+
+- **`window` イベント、エディター DOM イベントではない** -- macOS WKWebView のクリップボード許可プロンプトのトリガーを回避
+- **重複チェック** -- クリップボードの内容が既に保存されているものと異なる場合のみレジスタを更新（`keyBuffer.join("\n") !== text`）
+- **行単位の検出** -- クリップボードテキストが改行で終わる場合 `linewise: true` を設定。これにより `p` が現在の行の下にペーストされ、vim の行単位ペースト動作に一致
+
+<Note>
+
+`navigator.clipboard.readText()` にはクリップボード読み取り権限が必要です。一部のブラウザでは、ドキュメントがフォーカスされると自動的に権限が付与されます。その他のブラウザでは、ユーザーに権限プロンプトが表示される場合があります。権限が拒否された場合、catch ブロックがエラーを暗黙的に処理します。
+
+</Note>
+
 ## 完全な実装
 
-すべてをまとめた実装です。
+すべてをまとめた実装です。このバージョンはクリップボード同期に `window.focus` を使用し、標準ブラウザと Tauri/WKWebView 環境の両方と互換性があります。
 
 ```ts
 import { Vim } from "@replit/codemirror-vim";
@@ -180,33 +224,45 @@ function createClipboardRegister() {
   return register;
 }
 
-function setupClipboardIntegration(view: EditorView) {
+function setupClipboardIntegration(editorElement: HTMLElement) {
   const controller = Vim.getRegisterController();
   const registers = controller.registers;
   const clipboardRegister = createClipboardRegister();
 
-  // Replace system clipboard registers
+  // システムクリップボードレジスタを置き換え
   registers["*"] = clipboardRegister;
   registers["+"] = clipboardRegister;
 
-  // Make unnamed register use clipboard (clipboard=unnamedplus)
+  // 無名レジスタをクリップボードに設定 (clipboard=unnamedplus)
   registers['"'] = clipboardRegister;
   controller.unnamedRegister = clipboardRegister;
 
-  // Sync external clipboard on focus
-  view.dom.addEventListener("focus", async () => {
+  // window.focus で外部クリップボードを同期（エディターの focusin ではない）
+  // focusin を使用すると macOS WKWebView の「ペースト」許可メニューがトリガーされる
+  let cancelled = false;
+  const syncHandler = async () => {
+    if (cancelled) return;
     try {
       const text = await navigator.clipboard.readText();
-      if (text) {
+      if (cancelled) return;
+      if (text && clipboardRegister.keyBuffer.join("\n") !== text) {
         clipboardRegister.keyBuffer = [text];
-        clipboardRegister.linewise = false;
+        clipboardRegister.linewise = text.endsWith("\n");
         clipboardRegister.blockwise = false;
       }
     } catch {
       // clipboard-read permission denied
     }
-  });
+  };
+
+  window.addEventListener("focus", syncHandler);
+
+  // クリーンアップ関数を返す
+  return () => {
+    cancelled = true;
+    window.removeEventListener("focus", syncHandler);
+  };
 }
 ```
 
-EditorView の作成後に `setupClipboardIntegration(view)` を呼び出してください。
+EditorView の作成後に `setupClipboardIntegration(view.dom)` を呼び出してください。返されたクリーンアップ関数を保存し、エディター破棄時に呼び出してください。

--- a/src/content/docs-ja/vim-mode/vimrc.mdx
+++ b/src/content/docs-ja/vim-mode/vimrc.mdx
@@ -174,3 +174,78 @@ if (vimrc) {
   applyVimrc(view, vimrc);
 }
 ```
+
+## ファイルベース + 設定ベースの vimrc レイヤリング
+
+デスクトップアプリケーションでは、2つの vimrc ソースをサポートしたい場合があります。
+
+1. **ファイルベースの vimrc** -- ディスク上の `.vimrc` ファイル。バックエンド（例: Tauri IPC）経由でロード
+2. **設定ベースの vimrc** -- アプリケーション設定 UI に保存された vimrc 文字列
+
+レイヤリング戦略は、ファイルベースの vimrc を最初に適用し、次に設定ベースの vimrc を適用します。これにより、設定ベースのオーバーライドが優先され、ユーザーはディスクファイルを編集せずに動作をカスタマイズできます。
+
+```ts
+import { getCM, Vim } from "@replit/codemirror-vim";
+
+async function applyLayeredVimrc(
+  view: EditorView,
+  settingsVimrc: string,
+  readVimrcFromDisk: () => Promise<string | null>,
+) {
+  const cm = getCM(view);
+  if (!cm) return;
+
+  const applyVimrc = (source: string, label: string) => {
+    for (const cmd of parseVimrc(source)) {
+      try {
+        Vim.handleEx(cm, cmd);
+      } catch (e) {
+        console.warn(`${label} vimrc command failed: ${cmd}`, e);
+      }
+    }
+  };
+
+  // レイヤー 1: ファイルベースの vimrc（ディスクからロード）
+  const fileVimrc = await readVimrcFromDisk();
+  if (fileVimrc) {
+    applyVimrc(fileVimrc, "file-based");
+  }
+
+  // レイヤー 2: 設定ベースの vimrc（ファイルベースをオーバーライド）
+  if (settingsVimrc) {
+    applyVimrc(settingsVimrc, "settings");
+  }
+}
+```
+
+<Tip>
+
+このレイヤリングパターンはシェル設定の動作（`/etc/profile` の後に `~/.profile`）を模倣しています。ファイルベースの vimrc はマシンレベルのデフォルトを提供し、設定ベースの vimrc は UI を通じたアプリケーションごとのカスタマイズを可能にします。
+
+</Tip>
+
+### 非同期ロードの処理
+
+ファイルベースの vimrc はファイルシステム API 経由で非同期にロードされるため、vimrc の適用は `EditorView` の作成後に行われます。破棄されたエディターへの vimrc 適用を防ぐために、キャンセルガードを使用します。
+
+```ts
+let cancelled = false;
+
+readVimrcFromDisk().then((vimrcContent) => {
+  if (cancelled) return;
+  const cm = getCM(view);
+  if (!cm) return;
+
+  if (vimrcContent) {
+    applyVimrc(vimrcContent, "file-based");
+  }
+  if (settingsVimrc) {
+    applyVimrc(settingsVimrc, "settings");
+  }
+});
+
+// クリーンアップ時:
+cancelled = true;
+```
+
+これは、非同期の vimrc 読み取りが完了する前にエディターが破棄され再作成される可能性がある React アプリケーションで重要です。

--- a/src/content/docs/extensions/palette-theme-integration.mdx
+++ b/src/content/docs/extensions/palette-theme-integration.mdx
@@ -1,0 +1,241 @@
+---
+title: Palette-Based Theme System
+description: Create a CodeMirror theme driven entirely by CSS custom properties using an ANSI-style palette, color-mix() for opacity, and HighlightStyle tag mappings.
+sidebar_position: 7
+---
+
+# Palette-Based Theme System
+
+This page documents a theme architecture where CodeMirror gets all its colors from CSS custom properties following an ANSI terminal palette convention. The editor's appearance updates automatically when the CSS variables change, with no need to rebuild or reconfigure the theme.
+
+## The Palette
+
+The color scheme is defined as CSS custom properties on a parent element:
+
+```css
+:root {
+  --palette-fg: #c0c0c0;
+  --palette-bg: #1e1e2e;
+  --palette-cursor: #f5e0dc;
+  --palette-selection: rgba(88, 91, 112, 0.5);
+
+  /* ANSI-style palette: 0-15 */
+  --palette-0: #11111b; /* black   -- surfaces, gutters */
+  --palette-1: #f38ba8; /* red     -- invalid, errors */
+  --palette-2: #a6e3a1; /* green   -- strings */
+  --palette-3: #f9e2af; /* yellow  -- numbers, types */
+  --palette-4: #89b4fa; /* blue    -- keywords, headings */
+  --palette-5: #cba6f7; /* magenta -- functions, tags */
+  --palette-6: #94e2d5; /* cyan    -- operators, links */
+  --palette-7: #bac2de; /* white   -- punctuation */
+  --palette-8: #585b70; /* bright black -- comments */
+  --palette-15: #6c7086; /* bright white -- line numbers */
+}
+```
+
+This palette maps to the traditional 16-color ANSI terminal convention, which provides a natural mapping for syntax highlighting categories.
+
+## Editor UI Theme
+
+The editor theme uses `EditorView.theme()` with CSS custom properties for every color:
+
+```ts
+import { EditorView } from "@codemirror/view";
+
+function createEditorColorTheme(isDark: boolean) {
+  const baseTheme = EditorView.theme(
+    {
+      "&": {
+        color: "var(--palette-fg)",
+        backgroundColor: "var(--palette-bg)",
+      },
+      ".cm-content": {
+        caretColor: "var(--palette-cursor)",
+      },
+      ".cm-cursor, .cm-dropCursor": {
+        borderLeftColor: "var(--palette-cursor)",
+      },
+      "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
+        {
+          backgroundColor: "var(--palette-selection)",
+        },
+      ".cm-panels": {
+        backgroundColor: "var(--palette-0)",
+        color: "var(--palette-fg)",
+      },
+      ".cm-gutters": {
+        backgroundColor: "var(--palette-bg)",
+        color: "var(--palette-15)",
+        border: "none",
+      },
+    },
+    { dark: isDark },
+  );
+
+  // ... (highlight style below)
+  return [baseTheme];
+}
+```
+
+The `isDark` parameter tells CodeMirror whether this is a dark theme, which affects default styles for UI elements not explicitly styled.
+
+## Opacity with color-mix()
+
+For semi-transparent overlays (active line, search matches, selection matches), the theme uses `color-mix()` in the `oklch` color space:
+
+```ts
+".cm-activeLine": {
+  backgroundColor: "color-mix(in oklch, var(--palette-fg) 4%, transparent)",
+},
+".cm-searchMatch": {
+  backgroundColor: "color-mix(in oklch, var(--palette-3) 30%, transparent)",
+  outline: "1px solid color-mix(in oklch, var(--palette-3) 50%, transparent)",
+},
+".cm-searchMatch.cm-searchMatch-selected": {
+  backgroundColor: "color-mix(in oklch, var(--palette-3) 50%, transparent)",
+},
+".cm-selectionMatch": {
+  backgroundColor: "color-mix(in oklch, var(--palette-selection) 50%, transparent)",
+},
+"&.cm-focused .cm-matchingBracket, &.cm-focused .cm-nonmatchingBracket": {
+  backgroundColor: "color-mix(in oklch, var(--palette-4) 25%, transparent)",
+},
+```
+
+<Tip>
+
+`color-mix(in oklch, var(--some-color) 30%, transparent)` is a modern CSS alternative to `rgba()` with hardcoded values. It works with any color format and produces perceptually uniform blending in the oklch color space. It allows you to derive semi-transparent variants from opaque custom properties without defining additional variables.
+
+</Tip>
+
+## Syntax Highlighting with HighlightStyle
+
+The highlight style maps Lezer tags to palette colors:
+
+```ts
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags } from "@lezer/highlight";
+
+const highlightStyle = HighlightStyle.define([
+  // Comments
+  { tag: tags.comment, color: "var(--palette-8)" },
+
+  // Keywords & control flow
+  { tag: tags.keyword, color: "var(--palette-4)" },
+
+  // Functions & tags
+  {
+    tag: [
+      tags.function(tags.variableName),
+      tags.function(tags.definition(tags.variableName)),
+      tags.tagName,
+    ],
+    color: "var(--palette-5)",
+  },
+
+  // Strings
+  { tag: [tags.string, tags.special(tags.string)], color: "var(--palette-2)" },
+  { tag: tags.regexp, color: "var(--palette-6)" },
+  { tag: tags.escape, color: "var(--palette-6)" },
+
+  // Numbers, booleans, types
+  {
+    tag: [tags.number, tags.bool, tags.null, tags.typeName, tags.className, tags.namespace],
+    color: "var(--palette-3)",
+  },
+
+  // Variables & properties
+  { tag: [tags.variableName, tags.definition(tags.variableName)], color: "var(--palette-fg)" },
+  { tag: [tags.propertyName, tags.definition(tags.propertyName)], color: "var(--palette-4)" },
+
+  // Operators & punctuation
+  { tag: tags.operator, color: "var(--palette-6)" },
+  { tag: tags.punctuation, color: "var(--palette-7)" },
+  { tag: [tags.derefOperator, tags.separator], color: "var(--palette-fg)" },
+
+  // HTML/JSX attributes
+  { tag: tags.attributeName, color: "var(--palette-3)" },
+  { tag: tags.attributeValue, color: "var(--palette-2)" },
+
+  // Markdown markup
+  { tag: tags.heading, color: "var(--palette-4)", fontWeight: "bold" },
+  { tag: tags.emphasis, fontStyle: "italic", color: "var(--palette-5)" },
+  { tag: tags.strong, fontWeight: "bold", color: "var(--palette-3)" },
+  { tag: [tags.link, tags.url], color: "var(--palette-6)", textDecoration: "underline" },
+  { tag: tags.quote, color: "var(--palette-8)", fontStyle: "italic" },
+  { tag: tags.monospace, color: "var(--palette-2)" },
+  { tag: tags.strikethrough, textDecoration: "line-through" },
+
+  // Meta & invalid
+  { tag: tags.meta, color: "var(--palette-8)" },
+  { tag: tags.invalid, color: "var(--palette-1)" },
+]);
+```
+
+### Palette-to-Syntax Mapping
+
+| Palette Slot | ANSI Color | Syntax Category |
+| --- | --- | --- |
+| `--palette-1` | Red | Invalid tokens |
+| `--palette-2` | Green | Strings, attribute values, monospace |
+| `--palette-3` | Yellow | Numbers, types, booleans, attributes, strong text |
+| `--palette-4` | Blue | Keywords, properties, headings |
+| `--palette-5` | Magenta | Functions, tags, emphasis |
+| `--palette-6` | Cyan | Operators, regex, escape sequences, links |
+| `--palette-7` | White | Punctuation |
+| `--palette-8` | Bright black | Comments, quotes, meta |
+| `--palette-15` | Bright white | Line numbers |
+| `--palette-fg` | Foreground | Variables, separators, deref operators |
+
+## Returning the Complete Theme
+
+The function returns both the editor theme and the syntax highlighting as an array of extensions:
+
+```ts
+function createEditorColorTheme(isDark: boolean): Extension[] {
+  const baseTheme = EditorView.theme({ /* ... */ }, { dark: isDark });
+  const highlightStyle = HighlightStyle.define([ /* ... */ ]);
+  return [baseTheme, syntaxHighlighting(highlightStyle)];
+}
+```
+
+## Usage
+
+```ts
+const extensions = [
+  ...createEditorColorTheme(isDark),
+  // ... other extensions
+];
+```
+
+Switching themes at runtime only requires changing the CSS custom property values on the parent element. Because `HighlightStyle.define()` uses `var()` references (not resolved values), the colors update via CSS without reconfiguring CodeMirror.
+
+<Note>
+
+The `isDark` parameter passed to `EditorView.theme()` is a static boolean set at editor creation time. If the user switches between light and dark themes, the editor should be recreated with the correct `isDark` value. This only affects CodeMirror's default fallback styles for elements you have not explicitly themed.
+
+</Note>
+
+## Tooltip and Panel Styling
+
+The theme also covers tooltips, panels, and fold placeholders to maintain visual consistency:
+
+```ts
+".cm-tooltip": {
+  border: "1px solid var(--palette-0)",
+  backgroundColor: "var(--palette-bg)",
+},
+".cm-tooltip-autocomplete": {
+  "& > ul > li[aria-selected]": {
+    backgroundColor: "var(--palette-selection)",
+    color: "var(--palette-fg)",
+  },
+},
+".cm-foldPlaceholder": {
+  backgroundColor: "transparent",
+  border: "none",
+  color: "var(--palette-8)",
+},
+```
+
+Every visible surface in the editor uses a palette color, ensuring the editor looks correct regardless of which color scheme is active.

--- a/src/content/docs/recipes/bracket-colorization.mdx
+++ b/src/content/docs/recipes/bracket-colorization.mdx
@@ -1,0 +1,211 @@
+---
+title: Bracket Colorization
+description: Color-code matching brackets by nesting depth using a ViewPlugin, stack-based pairing, and CSS custom properties for theme-aware colors.
+sidebar_position: 7
+---
+
+# Bracket Colorization
+
+This recipe builds a CodeMirror extension that colorizes matching bracket pairs based on nesting depth. Each depth level gets a distinct color, cycling through a fixed palette. Only properly paired brackets receive colors -- unmatched brackets remain unstyled.
+
+## Overview
+
+The extension has three parts:
+
+1. **A pure scanner function** that finds matched bracket pairs and their nesting depths
+2. **A ViewPlugin** that caches scan results and builds decorations for visible ranges
+3. **A base theme** that maps CSS classes to colors via custom properties
+
+## Scanning for Bracket Pairs
+
+The scanner walks through the document text with a stack-based approach. Open brackets push onto the stack; close brackets pop the matching opener. Only matched pairs produce marks.
+
+```ts
+const OPEN_BRACKETS = new Set(["(", "[", "{"]);
+const CLOSE_BRACKETS: Record<string, string> = {
+  ")": "(",
+  "]": "[",
+  "}": "{",
+};
+
+interface BracketMark {
+  pos: number;
+  depth: number;
+}
+
+function findBracketPairs(text: string): BracketMark[] {
+  const stack: Array<{ char: string; pos: number; depth: number }> = [];
+  const pairs: Array<[number, number, number]> = [];
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (OPEN_BRACKETS.has(ch)) {
+      stack.push({ char: ch, pos: i, depth: stack.length });
+    } else if (ch in CLOSE_BRACKETS) {
+      const expected = CLOSE_BRACKETS[ch];
+      if (stack.length > 0 && stack[stack.length - 1].char === expected) {
+        const opener = stack.pop()!;
+        pairs.push([opener.pos, i, opener.depth]);
+      }
+    }
+  }
+
+  const marks: BracketMark[] = [];
+  for (const [openPos, closePos, depth] of pairs) {
+    marks.push({ pos: openPos, depth });
+    marks.push({ pos: closePos, depth });
+  }
+  marks.sort((a, b) => a.pos - b.pos);
+  return marks;
+}
+```
+
+Key design choices:
+
+- **Pure function** -- `findBracketPairs` takes a plain string and returns data. No CodeMirror dependency, easy to unit test.
+- **Mismatched brackets are silently ignored** -- If a `)` does not match the top of the stack, it is skipped. Unmatched openers remaining on the stack after the scan are also ignored.
+- **Marks are sorted by position** -- This is required by `RangeSetBuilder`, which expects decorations in document order.
+
+## Building Decorations
+
+The decoration builder filters cached marks to only the visible ranges, avoiding unnecessary DOM work for offscreen content.
+
+```ts
+import { Decoration, DecorationSet, EditorView } from "@codemirror/view";
+import { RangeSetBuilder } from "@codemirror/state";
+
+const COLOR_COUNT = 6;
+
+function buildDecorationsFromMarks(
+  marks: BracketMark[],
+  view: EditorView,
+): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const visibleRanges = view.visibleRanges;
+  let rangeIdx = 0;
+
+  for (const mark of marks) {
+    // Advance past visible ranges that end before this mark
+    while (
+      rangeIdx < visibleRanges.length &&
+      visibleRanges[rangeIdx].to <= mark.pos
+    ) {
+      rangeIdx++;
+    }
+
+    if (
+      rangeIdx < visibleRanges.length &&
+      mark.pos >= visibleRanges[rangeIdx].from &&
+      mark.pos < visibleRanges[rangeIdx].to
+    ) {
+      const colorIndex = mark.depth % COLOR_COUNT;
+      builder.add(
+        mark.pos,
+        mark.pos + 1,
+        Decoration.mark({ class: `cm-bracket-${colorIndex}` }),
+      );
+    }
+  }
+
+  return builder.finish();
+}
+```
+
+The depth-to-color mapping uses modulo arithmetic (`depth % COLOR_COUNT`), so colors cycle when nesting exceeds the palette size.
+
+## The ViewPlugin
+
+The plugin rescans the full document only when content changes. On viewport-only changes (scrolling), it reuses the cached marks and just re-filters them to the new visible ranges.
+
+```ts
+import { ViewPlugin, ViewUpdate } from "@codemirror/view";
+
+const bracketColorizePlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    marks: BracketMark[];
+
+    constructor(view: EditorView) {
+      this.marks = findBracketPairs(view.state.doc.toString());
+      this.decorations = buildDecorationsFromMarks(this.marks, view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged) {
+        this.marks = findBracketPairs(update.view.state.doc.toString());
+        this.decorations = buildDecorationsFromMarks(this.marks, update.view);
+      } else if (update.viewportChanged) {
+        this.decorations = buildDecorationsFromMarks(this.marks, update.view);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+```
+
+<Tip>
+
+The two-tier update strategy (`docChanged` vs `viewportChanged`) is important for performance. Scanning the full document text is O(n), but re-filtering cached marks against visible ranges is much cheaper and happens frequently during scrolling.
+
+</Tip>
+
+## Theme-Aware Colors with CSS Custom Properties
+
+The base theme assigns colors via CSS custom properties with sensible defaults. The host application can override these properties to match its color scheme.
+
+```ts
+const bracketColorizeTheme = EditorView.baseTheme({
+  ".cm-bracket-0": { color: "var(--bracket-color-0, #ffd700)" },
+  ".cm-bracket-1": { color: "var(--bracket-color-1, #da70d6)" },
+  ".cm-bracket-2": { color: "var(--bracket-color-2, #179fff)" },
+  ".cm-bracket-3": { color: "var(--bracket-color-3, #ffd700)" },
+  ".cm-bracket-4": { color: "var(--bracket-color-4, #da70d6)" },
+  ".cm-bracket-5": { color: "var(--bracket-color-5, #179fff)" },
+});
+```
+
+Using `EditorView.baseTheme()` (instead of `EditorView.theme()`) gives these styles lower precedence, so the application's theme can override them.
+
+The defaults cycle through gold, orchid, and blue -- three visually distinct colors that work on both light and dark backgrounds.
+
+## Exporting the Extension
+
+Bundle the plugin and theme together as a single extension:
+
+```ts
+import type { Extension } from "@codemirror/state";
+
+function bracketColorize(): Extension {
+  return [bracketColorizePlugin, bracketColorizeTheme];
+}
+```
+
+## Usage
+
+```ts
+const extensions = [
+  // ... other extensions
+  bracketColorize(),
+];
+```
+
+To customize colors, set CSS custom properties on a parent element:
+
+```css
+.my-editor {
+  --bracket-color-0: #e6b422;
+  --bracket-color-1: #c678dd;
+  --bracket-color-2: #61afef;
+  --bracket-color-3: #e6b422;
+  --bracket-color-4: #c678dd;
+  --bracket-color-5: #61afef;
+}
+```
+
+<Note>
+
+This approach scans the raw document text rather than using the syntax tree. It works well for markdown and plain text where brackets are not hidden inside string literals or comments. For a language-aware bracket colorizer, you would use `syntaxTree(state)` to walk only bracket tokens identified by the parser.
+
+</Note>

--- a/src/content/docs/recipes/display-scale-integration.mdx
+++ b/src/content/docs/recipes/display-scale-integration.mdx
@@ -1,0 +1,140 @@
+---
+title: Display Scale Integration
+description: Make CodeMirror responsive to a global display scale factor by computing scaled values in JavaScript and applying them via EditorView.theme().
+sidebar_position: 12
+---
+
+# Display Scale Integration
+
+This recipe shows how to make a CodeMirror editor responsive to a global display scale factor. The display scale is a multiplier (e.g., 1.0, 1.25, 1.5) that uniformly scales the editor's font size and padding, allowing users to zoom the editor independently of the browser zoom level.
+
+## The Pattern
+
+The approach computes scaled pixel values in JavaScript and applies them via `EditorView.theme()`. This is done at editor creation time, and the editor is recreated when the scale factor changes.
+
+```ts
+import { EditorView } from "@codemirror/view";
+
+const settings = {
+  fontSize: 14,
+  fontFamily: "Menlo",
+  lineHeight: 1.6,
+  paddingHorizontal: 16,
+  paddingVertical: 12,
+};
+
+const displayScale = 1.25;
+
+const scaledFontSize = settings.fontSize * displayScale;
+const scaledPaddingH = settings.paddingHorizontal * displayScale;
+const scaledPaddingV = settings.paddingVertical * displayScale;
+
+const editorTheme = EditorView.theme({
+  ".cm-scroller": {
+    fontFamily: `"${settings.fontFamily}", monospace`,
+    fontSize: `${scaledFontSize}px`,
+    lineHeight: String(settings.lineHeight),
+  },
+  ".cm-content": {
+    padding: `${scaledPaddingV}px 0`,
+  },
+  ".cm-line": {
+    paddingLeft: `${scaledPaddingH}px`,
+    paddingRight: `${scaledPaddingH}px`,
+  },
+});
+```
+
+## What Gets Scaled
+
+| Property | Base Value | At 1.25x |
+| --- | --- | --- |
+| Font size | 14px | 17.5px |
+| Horizontal padding | 16px | 20px |
+| Vertical padding | 12px | 15px |
+
+Line height is a unitless ratio (e.g., 1.6) and does not need scaling -- it automatically adjusts because it is relative to the font size.
+
+## Why Scale in JavaScript Instead of CSS?
+
+An alternative approach would be to use a CSS `transform: scale()` or a CSS custom property like `--display-scale` with `calc()`. However, scaling via JavaScript and `EditorView.theme()` has advantages:
+
+- **Pixel-perfect values** -- CodeMirror needs to know the exact font size for cursor positioning, line height calculations, and viewport measurements. CSS transforms can cause sub-pixel rendering issues.
+- **No layout disruption** -- CSS `transform: scale()` does not change the element's layout size, which breaks CodeMirror's scroll calculations.
+- **Gutter alignment** -- When line numbers are shown, the gutter padding must also scale. This is straightforward with computed values.
+
+```ts
+const themeRules: Record<string, Record<string, string>> = {
+  ".cm-scroller": {
+    fontFamily: `"${settings.fontFamily}", monospace`,
+    fontSize: `${scaledFontSize}px`,
+    lineHeight: String(settings.lineHeight),
+  },
+  ".cm-content": {
+    padding: `${scaledPaddingV}px 0`,
+  },
+  ".cm-line": {
+    paddingLeft: `${scaledPaddingH}px`,
+    paddingRight: `${scaledPaddingH}px`,
+  },
+};
+
+// Scale gutter padding when line numbers are visible
+if (showLineNumbers) {
+  themeRules[".cm-gutters"] = {
+    paddingTop: `${scaledPaddingV}px`,
+  };
+}
+
+const editorTheme = EditorView.theme(themeRules);
+```
+
+## Integration with a CSS Custom Property
+
+The rest of the application (outside CodeMirror) may use a CSS custom property for scaling:
+
+```css
+:root {
+  --display-scale: 1.25;
+}
+
+.sidebar {
+  font-size: calc(13px * var(--display-scale));
+}
+```
+
+CodeMirror does not use this CSS property directly. Instead, the JavaScript layer reads the same scale value from the settings object and computes pixel values. This keeps CodeMirror's internal measurements accurate while the rest of the UI uses the CSS approach.
+
+## Recreating vs Reconfiguring
+
+In this pattern, the editor is recreated when the display scale changes. This is the simplest approach because `EditorView.theme()` generates scoped CSS rules at creation time -- they cannot be updated in place.
+
+```ts
+// React hook example
+useEffect(() => {
+  const editorTheme = EditorView.theme({
+    ".cm-scroller": {
+      fontSize: `${settings.fontSize * displayScale}px`,
+    },
+  });
+
+  const view = new EditorView({
+    state: EditorState.create({ doc: content, extensions: [editorTheme] }),
+    parent: containerRef.current,
+  });
+
+  return () => view.destroy();
+}, [settings, displayScale]);
+```
+
+<Note>
+
+Recreating the editor is appropriate when the display scale changes because it is an infrequent operation (the user adjusts it in settings, not during active typing). The cost of destroying and recreating an `EditorView` is low compared to the complexity of dynamically updating theme rules.
+
+</Note>
+
+<Tip>
+
+When recreating the editor, preserve the document content and scroll position. Pass the current content as the initial `doc`, and restore `scrollDOM.scrollTop` after the new view is created.
+
+</Tip>

--- a/src/content/docs/recipes/indent-guides.mdx
+++ b/src/content/docs/recipes/indent-guides.mdx
@@ -1,0 +1,204 @@
+---
+title: Indent Guides
+description: Render vertical indent guide lines in CodeMirror using line decorations, CSS custom properties, and a repeating linear gradient.
+sidebar_position: 8
+---
+
+# Indent Guides
+
+This recipe builds a CodeMirror extension that renders vertical indent guide lines at each indentation level. The guides are drawn entirely with CSS -- no canvas or SVG -- using a repeating linear gradient on a pseudo-element.
+
+## Overview
+
+The approach works as follows:
+
+1. For each visible line, count the indentation level (number of leading spaces or tabs)
+2. Add a line decoration with a CSS custom property `--indent-level` set to the level count
+3. A `::before` pseudo-element draws vertical lines using a repeating gradient
+
+## Counting Indentation
+
+The indent counter converts both spaces and tabs to a uniform level based on a fixed unit width. For markdown, the convention is 2-space indentation for nested lists.
+
+```ts
+const INDENT_UNIT = 2;
+const MAX_INDENT_LEVEL = 10;
+
+function countIndentLevel(line: string): number {
+  let spaces = 0;
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] === " ") {
+      spaces++;
+    } else if (line[i] === "\t") {
+      spaces += INDENT_UNIT;
+    } else {
+      break;
+    }
+  }
+  // Skip whitespace-only lines -- no guides on blank lines
+  if (spaces >= line.length) return 0;
+  return Math.min(Math.floor(spaces / INDENT_UNIT), MAX_INDENT_LEVEL);
+}
+```
+
+<Note>
+
+Whitespace-only lines return 0 to avoid drawing guides on blank lines. This prevents distracting vertical lines in empty regions of the document. `MAX_INDENT_LEVEL` caps the decoration count to guard against pathological input.
+
+</Note>
+
+## Building Line Decorations
+
+For each visible line with indentation, a line decoration sets the `--indent-level` custom property. The CSS theme uses this value to determine the width of the gradient area.
+
+```ts
+import {
+  ViewPlugin,
+  Decoration,
+  DecorationSet,
+  EditorView,
+  ViewUpdate,
+} from "@codemirror/view";
+import { RangeSetBuilder } from "@codemirror/state";
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+
+  for (const { from, to } of view.visibleRanges) {
+    let pos = from;
+    while (pos <= to) {
+      const line = view.state.doc.lineAt(pos);
+      const level = countIndentLevel(line.text);
+
+      if (level > 0) {
+        builder.add(
+          line.from,
+          line.from,
+          Decoration.line({
+            attributes: {
+              class: "cm-indent-guides",
+              style: `--indent-level: ${level}`,
+            },
+          }),
+        );
+      }
+
+      pos = line.to + 1;
+    }
+  }
+
+  return builder.finish();
+}
+```
+
+## The ViewPlugin
+
+The plugin rebuilds decorations on document changes and viewport scrolling.
+
+```ts
+const indentGuidesPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.viewportChanged) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+```
+
+## CSS Theme: The Repeating Gradient Technique
+
+The theme uses a `::before` pseudo-element with a repeating linear gradient to draw the guide lines. Each "column" is `2ch` wide (matching `INDENT_UNIT`), with a 1px line at the left edge.
+
+```ts
+const indentGuidesTheme = EditorView.baseTheme({
+  ".cm-indent-guides": {
+    position: "relative",
+  },
+  ".cm-indent-guides::before": {
+    content: '""',
+    position: "absolute",
+    top: "0",
+    bottom: "0",
+    left: "calc(-1 * var(--cm-hang, 0px))",
+    width: "calc(2ch * var(--indent-level, 0))",
+    paddingLeft: "inherit",
+    backgroundImage: [
+      "repeating-linear-gradient(to right,",
+      "color-mix(in oklch, var(--palette-fg) 12%, transparent) 0px,",
+      "color-mix(in oklch, var(--palette-fg) 12%, transparent) 1px,",
+      "transparent 1px,",
+      "transparent 2ch)",
+    ].join(" "),
+    backgroundOrigin: "content-box",
+    backgroundRepeat: "no-repeat",
+    pointerEvents: "none",
+  },
+});
+```
+
+How this works:
+
+- **`width: calc(2ch * var(--indent-level, 0))`** -- The pseudo-element is exactly wide enough to cover all indentation columns
+- **`repeating-linear-gradient`** -- Draws a 1px vertical line every `2ch`, creating one guide per indent level
+- **`color-mix(in oklch, var(--palette-fg) 12%, transparent)`** -- Makes the guides subtly visible by mixing the foreground color at 12% opacity. This adapts automatically to light and dark themes
+- **`backgroundOrigin: content-box`** with `paddingLeft: inherit` -- Ensures the gradient starts after the editor's horizontal padding
+- **`left: calc(-1 * var(--cm-hang, 0px))`** -- Offsets the pseudo-element to compensate for the hanging indent applied by a list-hanging-indent extension (see [Markdown List Handling](/docs/recipes/markdown-list-handling/))
+- **`pointerEvents: none`** -- Prevents the pseudo-element from intercepting clicks
+
+<Tip>
+
+The `ch` unit is based on the width of the `0` character in the current font. This works well with monospace fonts. With proportional fonts, the guide alignment will be approximate.
+
+</Tip>
+
+## Exporting the Extension
+
+```ts
+import type { Extension } from "@codemirror/state";
+
+function indentGuides(): Extension {
+  return [indentGuidesPlugin, indentGuidesTheme];
+}
+```
+
+## Usage
+
+```ts
+const extensions = [
+  // ... other extensions
+  indentGuides(),
+];
+```
+
+To change the guide color, override the CSS custom property used in `color-mix`. Alternatively, replace the gradient in your application's theme:
+
+```ts
+const customGuideTheme = EditorView.theme({
+  ".cm-indent-guides::before": {
+    backgroundImage: [
+      "repeating-linear-gradient(to right,",
+      "rgba(128, 128, 128, 0.15) 0px,",
+      "rgba(128, 128, 128, 0.15) 1px,",
+      "transparent 1px,",
+      "transparent 2ch)",
+    ].join(" "),
+  },
+});
+```
+
+<Warning>
+
+Line decorations are applied to `.cm-line` elements. If another extension (such as hanging indent) also adds line decorations with `margin-left` or `text-indent`, the indent guides pseudo-element must account for the offset. The `left: calc(-1 * var(--cm-hang, 0px))` pattern shown above handles this by reading a CSS custom property set by the hanging indent extension.
+
+</Warning>

--- a/src/content/docs/recipes/markdown-list-handling.mdx
+++ b/src/content/docs/recipes/markdown-list-handling.mdx
@@ -1,0 +1,277 @@
+---
+title: Markdown List Handling
+description: Two complementary extensions for markdown lists -- auto-continuation of list markers on Enter and hanging indent for wrapped lines using syntax tree analysis.
+sidebar_position: 11
+---
+
+# Markdown List Handling
+
+This recipe covers two complementary CodeMirror extensions for working with markdown lists:
+
+1. **List continuation** -- Auto-continues list markers when pressing Enter, auto-increments numbers, and removes empty list items
+2. **Hanging indent** -- Aligns wrapped lines with the content after the list marker
+
+Together, these extensions create an Obsidian-like editing experience for markdown lists.
+
+## Why Custom Instead of Built-In?
+
+CodeMirror's `@codemirror/lang-markdown` provides `insertNewlineContinueMarkup`, which handles basic list continuation. However, a custom implementation offers more control over:
+
+- **Checkbox continuation** -- Inserting unchecked `[ ]` checkboxes when continuing a task list
+- **Cursor-at-end requirement** -- Only triggering when the cursor is at the end of the line, not mid-line
+- **Empty item behavior** -- Clearing the entire line (not just removing the prefix) when the list item has no content
+
+The hanging indent extension is entirely custom -- CodeMirror does not provide a built-in equivalent.
+
+## Part 1: List Continuation
+
+### Regex-Based List Detection
+
+The extension uses a regex to detect list markers at the start of a line:
+
+```ts
+const listMarkerRe = /^(\s*)([-*+]|\d+\.)\s(\[[ xX]\]\s)?/;
+```
+
+This matches:
+
+- Optional leading whitespace (`\s*`)
+- A list marker: `-`, `*`, `+`, or a number followed by `.`
+- A required space after the marker
+- An optional checkbox (`[ ]`, `[x]`, or `[X]`) with trailing space
+
+### Computing the Next Marker
+
+```ts
+function getNextListMarker(
+  lineText: string,
+): { prefix: string; isEmpty: boolean } | null {
+  const match = lineText.match(listMarkerRe);
+  if (!match) return null;
+
+  const [fullMatch, indent, marker, checkbox] = match;
+  const textAfterMarker = lineText.slice(fullMatch.length);
+  const isEmpty = textAfterMarker.trim() === "";
+
+  let nextMarker = marker;
+  if (/^\d+\./.test(marker)) {
+    const num = parseInt(marker, 10);
+    nextMarker = `${num + 1}.`;
+  }
+
+  const nextCheckbox = checkbox ? "[ ] " : "";
+  const prefix = `${indent}${nextMarker} ${nextCheckbox}`;
+
+  return { prefix, isEmpty };
+}
+```
+
+Numbered lists are auto-incremented: if the current line starts with `3.`, the next line gets `4.`. Checkbox lists continue with an unchecked box `[ ]`.
+
+### The Keymap Handler
+
+```ts
+import { EditorView, keymap } from "@codemirror/view";
+
+function handleEnterInList(view: EditorView): boolean {
+  const { state } = view;
+  const { from, to } = state.selection.main;
+
+  // Only handle single cursor (no selection range)
+  if (from !== to) return false;
+
+  const line = state.doc.lineAt(from);
+
+  // Only trigger when cursor is at the end of the line
+  if (from !== line.to) return false;
+
+  const result = getNextListMarker(line.text);
+  if (!result) return false;
+
+  // Empty list item -- remove the marker line to exit the list
+  if (result.isEmpty) {
+    view.dispatch({
+      changes: { from: line.from, to: line.to, insert: "" },
+    });
+    return true;
+  }
+
+  // Insert new line with continued marker
+  const newLine = `\n${result.prefix}`;
+  view.dispatch({
+    changes: { from, to: from, insert: newLine },
+    selection: { anchor: from + newLine.length },
+    scrollIntoView: true,
+  });
+  return true;
+}
+
+function markdownListIndent() {
+  return keymap.of([
+    { key: "Enter", run: handleEnterInList },
+  ]);
+}
+```
+
+<Tip>
+
+The handler returns `false` when it does not apply (non-list line, cursor not at end, active selection). This allows other keybindings for the Enter key to handle the event. Returning `true` stops propagation.
+
+</Tip>
+
+### Behavior Summary
+
+| Current Line | Action |
+| --- | --- |
+| `- Item text` | Insert `\n- ` and place cursor after the marker |
+| `3. Item text` | Insert `\n4. ` (auto-increment) |
+| `- [ ] Task` | Insert `\n- [ ] ` (unchecked checkbox) |
+| `- ` (empty item) | Clear the line entirely, exiting the list |
+
+## Part 2: Hanging Indent
+
+When a long list item wraps to the next visual line, the default behavior left-aligns the continuation text with the list marker. Hanging indent aligns it with the content *after* the marker instead.
+
+```
+Without hanging indent:
+- This is a long list item that wraps to
+the next visual line
+
+With hanging indent:
+- This is a long list item that wraps to
+  the next visual line
+```
+
+### Measuring Marker Width with the Syntax Tree
+
+The extension uses the Lezer syntax tree to identify `ListItem` nodes, then measures the marker prefix width:
+
+```ts
+import { syntaxTree } from "@codemirror/language";
+import { countColumn } from "@codemirror/state";
+
+const listPrefixRe =
+  /^([ \t]*)([-*+]|\d+\.)( {1,4}\[[ xX]\])? {1,4}/;
+
+function getMarkerWidth(text: string, tabSize: number): number {
+  const m = listPrefixRe.exec(text);
+  if (!m) return 0;
+  const markerOnly = m[0].slice(m[1].length);
+  return countColumn(markerOnly, tabSize);
+}
+```
+
+The marker width is measured using `countColumn` from CodeMirror's state module, which accounts for tab characters correctly. The leading whitespace is excluded because CodeMirror handles that via normal indentation.
+
+### Building Decorations
+
+```ts
+import {
+  ViewPlugin,
+  Decoration,
+  DecorationSet,
+  EditorView,
+  ViewUpdate,
+} from "@codemirror/view";
+import { RangeSetBuilder } from "@codemirror/state";
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const tree = syntaxTree(view.state);
+  const seen = new Set<number>();
+
+  for (const { from, to } of view.visibleRanges) {
+    tree.iterate({
+      from,
+      to,
+      enter(node) {
+        if (node.name !== "ListItem") return;
+
+        const line = view.state.doc.lineAt(node.from);
+        if (seen.has(line.from)) return;
+        seen.add(line.from);
+
+        const cols = getMarkerWidth(line.text, view.state.tabSize);
+        if (cols <= 0) return;
+
+        builder.add(
+          line.from,
+          line.from,
+          Decoration.line({
+            attributes: {
+              class: "cm-list-hanging-indent",
+              style: `--cm-hang: ${cols}ch`,
+            },
+          }),
+        );
+      },
+    });
+  }
+
+  return builder.finish();
+}
+```
+
+The `seen` set prevents duplicate decorations when the syntax tree yields multiple `ListItem` nodes starting on the same line.
+
+### The CSS Technique
+
+The hanging indent is achieved with a CSS custom property `--cm-hang` that drives `margin-left` and `text-indent`:
+
+```ts
+const listHangingIndentTheme = EditorView.baseTheme({
+  ".cm-list-hanging-indent": {
+    marginLeft: "var(--cm-hang)",
+    textIndent: "calc(-1 * var(--cm-hang))",
+  },
+});
+```
+
+How this works:
+
+- `margin-left: var(--cm-hang)` shifts the entire line (including wrapped text) to the right
+- `text-indent: calc(-1 * var(--cm-hang))` pulls the first line back to its original position
+
+The result: the first line starts at the normal position, and wrapped lines are indented to align with the content after the marker.
+
+<Warning>
+
+The `ch` unit assumes a monospace font. With proportional fonts, the alignment will be approximate because character widths vary. For precise alignment with proportional fonts, you would need to measure the actual pixel width of the prefix text.
+
+</Warning>
+
+### Syntax Tree Updates
+
+The plugin rebuilds decorations not only on `docChanged` and `viewportChanged`, but also when the syntax tree itself changes:
+
+```ts
+update(update: ViewUpdate) {
+  if (
+    update.docChanged ||
+    update.viewportChanged ||
+    syntaxTree(update.startState) !== syntaxTree(update.state)
+  ) {
+    this.decorations = buildDecorations(update.view);
+  }
+}
+```
+
+This handles the case where the Lezer parser runs incrementally and the tree updates asynchronously after a document change.
+
+## Using Both Extensions Together
+
+The `margin-left` / `text-indent` approach used by the hanging indent extension also affects the indent guides extension (see [Indent Guides](/docs/recipes/indent-guides/)). The indent guides use `left: calc(-1 * var(--cm-hang, 0px))` on their pseudo-element to compensate for the margin shift, ensuring guides align correctly on both list and non-list lines.
+
+```ts
+const extensions = [
+  // ... other extensions
+  markdownListIndent(),
+  listHangingIndent(),
+];
+```
+
+<Note>
+
+Using `margin-left` (not `padding-left`) for the hanging indent is deliberate. CodeMirror's theme sets `padding-left` on `.cm-line` for horizontal padding. Using `margin-left` avoids overriding that padding and allows both to coexist.
+
+</Note>

--- a/src/content/docs/recipes/scrollbar-cursor-indicator.mdx
+++ b/src/content/docs/recipes/scrollbar-cursor-indicator.mdx
@@ -1,0 +1,193 @@
+---
+title: Scrollbar Cursor Indicator
+description: Show the cursor position as a thin horizontal line on the scrollbar track using a ViewPlugin with DOM manipulation.
+sidebar_position: 10
+---
+
+# Scrollbar Cursor Indicator
+
+This recipe builds a CodeMirror extension that displays the cursor's position as a thin horizontal line on the scrollbar track, similar to the minimap cursor indicator in VS Code. It gives users a quick visual reference of where they are in a long document.
+
+## Overview
+
+The extension creates a small `<div>` element positioned absolutely inside the editor's DOM. The element is positioned vertically based on the cursor's relative position in the document. It updates on selection changes, document changes, and geometry changes.
+
+## Implementation
+
+```ts
+import { EditorView, ViewPlugin, ViewUpdate } from "@codemirror/view";
+
+const SCROLLBAR_WIDTH = "14px";
+
+function scrollbarCursorIndicator() {
+  return ViewPlugin.fromClass(
+    class {
+      private indicator: HTMLDivElement;
+      private pendingFrame = 0;
+      private focused: boolean;
+      private readonly onFocus: () => void;
+      private readonly onBlur: () => void;
+
+      constructor(private view: EditorView) {
+        this.indicator = document.createElement("div");
+        Object.assign(this.indicator.style, {
+          position: "absolute",
+          right: "0",
+          width: SCROLLBAR_WIDTH,
+          height: "2px",
+          pointerEvents: "none",
+          zIndex: "10",
+          background: "var(--palette-cursor)",
+        });
+        view.dom.appendChild(this.indicator);
+
+        this.focused = view.hasFocus;
+        this.updatePosition();
+
+        this.onFocus = () => {
+          this.focused = true;
+          this.updatePosition();
+        };
+        this.onBlur = () => {
+          this.focused = false;
+          this.indicator.style.display = "none";
+        };
+        view.dom.addEventListener("focusin", this.onFocus);
+        view.dom.addEventListener("focusout", this.onBlur);
+      }
+
+      update(update: ViewUpdate) {
+        if (
+          update.selectionSet ||
+          update.docChanged ||
+          update.geometryChanged
+        ) {
+          if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+          this.pendingFrame = requestAnimationFrame(() => {
+            this.pendingFrame = 0;
+            this.updatePosition();
+          });
+        }
+      }
+
+      private updatePosition() {
+        if (!this.focused) {
+          this.indicator.style.display = "none";
+          return;
+        }
+
+        const { scrollDOM, state } = this.view;
+        const { scrollHeight, clientHeight } = scrollDOM;
+
+        // Hide when content doesn't scroll
+        if (scrollHeight <= clientHeight) {
+          this.indicator.style.display = "none";
+          return;
+        }
+        this.indicator.style.display = "";
+
+        const head = state.selection.main.head;
+        const block = this.view.lineBlockAt(head);
+        const contentH = this.view.contentHeight;
+        const ratio = contentH > 0 ? block.top / contentH : 0;
+        const scrollerTop = scrollDOM.offsetTop;
+        const trackHeight = clientHeight;
+        this.indicator.style.top = `${scrollerTop + ratio * trackHeight}px`;
+      }
+
+      destroy() {
+        if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+        this.view.dom.removeEventListener("focusin", this.onFocus);
+        this.view.dom.removeEventListener("focusout", this.onBlur);
+        this.indicator.remove();
+      }
+    },
+  );
+}
+```
+
+## Key Design Decisions
+
+### Position Calculation
+
+The indicator's vertical position is calculated as a ratio of the cursor's line position to the total content height:
+
+```
+ratio = lineBlock.top / contentHeight
+indicatorTop = scrollerTop + ratio * trackHeight
+```
+
+`lineBlockAt(head)` returns the visual line block at the cursor position, giving us the pixel offset from the top of the content. Dividing by `contentHeight` gives a 0-to-1 ratio that maps to the scrollbar track.
+
+<Note>
+
+The extension uses `contentHeight` (the height of actual document content) rather than `scrollHeight` (which may include `scrollPastEnd()` padding). This prevents the indicator from being pushed to an artificially low position when the editor has extra scrollable space after the last line.
+
+</Note>
+
+### Focus-Aware Visibility
+
+The indicator is only shown when the editor has focus. In a split-pane editor, multiple CodeMirror instances may be visible simultaneously. Without focus awareness, each pane would show its own indicator, creating visual clutter.
+
+```ts
+this.onFocus = () => {
+  this.focused = true;
+  this.updatePosition();
+};
+this.onBlur = () => {
+  this.focused = false;
+  this.indicator.style.display = "none";
+};
+```
+
+The plugin initializes `this.focused` from `view.hasFocus` rather than defaulting to `true`. This handles cases where the editor is created without receiving focus (such as a newly opened split pane).
+
+### DOM Approach vs Decoration
+
+This extension uses direct DOM manipulation (appending a `<div>` to `view.dom`) rather than CodeMirror decorations. This is because the indicator is positioned relative to the scrollbar, not relative to document content. Decorations are designed to annotate document ranges and would not work for an overlay on the scrollbar track.
+
+### requestAnimationFrame
+
+Position updates are batched with `requestAnimationFrame` to avoid layout thrashing when multiple events fire in quick succession (e.g., typing rapidly).
+
+## Cleanup
+
+The `destroy` method removes the indicator element, cancels pending animation frames, and removes event listeners:
+
+```ts
+destroy() {
+  if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+  this.view.dom.removeEventListener("focusin", this.onFocus);
+  this.view.dom.removeEventListener("focusout", this.onBlur);
+  this.indicator.remove();
+}
+```
+
+<Warning>
+
+Always remove event listeners in the `destroy` method. Without cleanup, listeners would accumulate if the extension is reconfigured or the editor is recreated.
+
+</Warning>
+
+## Usage
+
+```ts
+const extensions = [
+  // ... other extensions
+  scrollbarCursorIndicator(),
+];
+```
+
+To change the indicator color, set a CSS custom property:
+
+```css
+.my-editor {
+  --palette-cursor: #528bff;
+}
+```
+
+Or modify the `background` value in the indicator style to use a fixed color:
+
+```ts
+background: "rgba(82, 139, 255, 0.8)",
+```

--- a/src/content/docs/recipes/settings-driven-editor.mdx
+++ b/src/content/docs/recipes/settings-driven-editor.mdx
@@ -1,0 +1,254 @@
+---
+title: Settings-Driven Editor Configuration
+description: Configure CodeMirror entirely from an application settings object, using compartments for runtime reconfiguration and a shared schema for validation.
+sidebar_position: 13
+---
+
+# Settings-Driven Editor Configuration
+
+This recipe documents the pattern of configuring a CodeMirror editor entirely from an application settings object. All editor behavior -- font, indentation, feature toggles -- flows from a single settings source, validated by a shared schema.
+
+## The Settings Object
+
+The editor settings are a plain object with typed fields:
+
+```ts
+interface EditorSettings {
+  fontFamily: string;
+  fontSize: number;
+  lineHeight: number;
+  paddingHorizontal: number;
+  paddingVertical: number;
+  indentType: "tab" | "spaces";
+  indentSize: number;
+  vimMode: boolean;
+  typewriterScrolling: boolean;
+  showIndentGuides: boolean;
+  bracketColorization: boolean;
+  markdownListIndent: boolean;
+  listHangingIndent: boolean;
+  showStatusBar: boolean;
+}
+```
+
+Default values are defined in a shared package so that both the frontend and the settings validation logic use the same defaults:
+
+```ts
+const defaultEditorSettings: EditorSettings = {
+  fontFamily: "Menlo",
+  fontSize: 14,
+  lineHeight: 1.6,
+  paddingHorizontal: 16,
+  paddingVertical: 12,
+  indentType: "spaces",
+  indentSize: 2,
+  vimMode: false,
+  typewriterScrolling: false,
+  showIndentGuides: true,
+  bracketColorization: true,
+  markdownListIndent: true,
+  listHangingIndent: true,
+  showStatusBar: true,
+};
+```
+
+## Mapping Settings to Extensions
+
+Each setting maps to one or more CodeMirror extensions or configuration options. The extensions array is built dynamically based on the current settings:
+
+```ts
+import { EditorState, Compartment } from "@codemirror/state";
+import { EditorView, keymap, lineNumbers, scrollPastEnd } from "@codemirror/view";
+import { indentUnit } from "@codemirror/language";
+import { indentWithTab } from "@codemirror/commands";
+import { vim } from "@replit/codemirror-vim";
+
+function buildExtensions(settings: EditorSettings) {
+  return [
+    // Vim mode (conditional)
+    ...(settings.vimMode ? [vim()] : []),
+
+    // Font and layout via theme
+    EditorView.theme({
+      ".cm-scroller": {
+        fontFamily: `"${settings.fontFamily}", monospace`,
+        fontSize: `${settings.fontSize}px`,
+        lineHeight: String(settings.lineHeight),
+      },
+      ".cm-content": {
+        padding: `${settings.paddingVertical}px 0`,
+      },
+      ".cm-line": {
+        paddingLeft: `${settings.paddingHorizontal}px`,
+        paddingRight: `${settings.paddingHorizontal}px`,
+      },
+    }),
+
+    // Indentation
+    EditorState.tabSize.of(settings.indentSize),
+    indentUnit.of(
+      settings.indentType === "tab"
+        ? "\t"
+        : " ".repeat(settings.indentSize),
+    ),
+    keymap.of([indentWithTab]),
+
+    // Feature toggles
+    ...(settings.markdownListIndent ? [markdownListIndent()] : []),
+    ...(settings.listHangingIndent ? [listHangingIndent()] : []),
+    ...(settings.showIndentGuides ? [indentGuides()] : []),
+    ...(settings.typewriterScrolling ? [typewriterScrolling()] : []),
+    ...(settings.bracketColorization ? [bracketColorize()] : []),
+
+    scrollPastEnd(),
+  ];
+}
+```
+
+### Font Configuration
+
+Font family, size, line height, and padding are all applied via `EditorView.theme()`. These values cannot be set as CSS custom properties *for CodeMirror* because CodeMirror needs exact pixel values for its internal layout calculations.
+
+### Indentation
+
+Two CodeMirror primitives control indentation:
+
+- `EditorState.tabSize.of(n)` -- Sets the visual width of tab characters
+- `indentUnit.of(unit)` -- Sets what gets inserted when the user presses Tab. A `"\t"` string inserts a tab character; a string of spaces inserts that many spaces
+
+### Feature Toggles
+
+Optional extensions are conditionally included using the spread operator with a ternary:
+
+```ts
+...(settings.typewriterScrolling ? [typewriterScrolling()] : []),
+```
+
+This pattern is clear and avoids nested if-else blocks. Each toggle adds or omits the corresponding extension.
+
+## Compartments for Runtime Reconfiguration
+
+Some settings can be changed at runtime without recreating the editor. CodeMirror [Compartments](/docs/extensions/compartments/) make this possible.
+
+```ts
+const readOnlyCompartment = new Compartment();
+
+const extensions = [
+  readOnlyCompartment.of(EditorState.readOnly.of(false)),
+  // ... other extensions
+];
+
+// Later, toggle readOnly:
+view.dispatch({
+  effects: readOnlyCompartment.reconfigure(EditorState.readOnly.of(true)),
+});
+```
+
+Compartments are useful for settings that change frequently (like read-only mode in a split pane). For settings that change infrequently (like font size or vim mode), recreating the editor is simpler and avoids the complexity of managing many compartments.
+
+<Tip>
+
+A practical guideline: use compartments for settings that change during active editing (read-only toggle, line wrapping). Recreate the editor for settings that change via a settings dialog (font, indentation, feature toggles). The cost of recreating an `EditorView` is low because CodeMirror is designed for fast initialization.
+
+</Tip>
+
+## Validation and Defaults
+
+A shared schema package validates settings and applies defaults:
+
+```ts
+function validateEditorSettings(input: Partial<EditorSettings>): EditorSettings {
+  return {
+    fontFamily: input.fontFamily || defaultEditorSettings.fontFamily,
+    fontSize: clamp(input.fontSize ?? defaultEditorSettings.fontSize, 10, 24),
+    lineHeight: input.lineHeight ?? defaultEditorSettings.lineHeight,
+    paddingHorizontal: clamp(
+      input.paddingHorizontal ?? defaultEditorSettings.paddingHorizontal,
+      0,
+      48,
+    ),
+    paddingVertical: clamp(
+      input.paddingVertical ?? defaultEditorSettings.paddingVertical,
+      0,
+      48,
+    ),
+    indentType: input.indentType === "tab" ? "tab" : "spaces",
+    indentSize: clamp(input.indentSize ?? defaultEditorSettings.indentSize, 1, 8),
+    vimMode: input.vimMode ?? defaultEditorSettings.vimMode,
+    typewriterScrolling: input.typewriterScrolling ?? defaultEditorSettings.typewriterScrolling,
+    showIndentGuides: input.showIndentGuides ?? defaultEditorSettings.showIndentGuides,
+    bracketColorization: input.bracketColorization ?? defaultEditorSettings.bracketColorization,
+    markdownListIndent: input.markdownListIndent ?? defaultEditorSettings.markdownListIndent,
+    listHangingIndent: input.listHangingIndent ?? defaultEditorSettings.listHangingIndent,
+    showStatusBar: input.showStatusBar ?? defaultEditorSettings.showStatusBar,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+```
+
+This validation ensures that regardless of what a user puts in the settings file, the editor always receives safe values within expected ranges. The same validation function is used on both the backend (when reading settings from disk) and the frontend (before passing to CodeMirror).
+
+## React Integration Pattern
+
+In a React application, the editor is recreated when settings change via a `useEffect` dependency:
+
+```ts
+useEffect(() => {
+  if (!containerRef.current || !settings) return;
+
+  const extensions = buildExtensions(settings);
+  const state = EditorState.create({ doc: content, extensions });
+  const view = new EditorView({ state, parent: containerRef.current });
+
+  return () => view.destroy();
+}, [settings]);
+```
+
+The `settings` object is memoized so the effect only re-runs when actual values change:
+
+```ts
+const settings = useMemo(
+  () => appSettings
+    ? { ...defaultEditorSettings, ...appSettings.editor }
+    : null,
+  [appSettings],
+);
+```
+
+<Note>
+
+When the editor is recreated, the document content and scroll position should be preserved. The `content` prop provides the current document, and scroll position can be saved and restored via `view.scrollDOM.scrollTop`.
+
+</Note>
+
+## Settings UI
+
+Each setting corresponds to a form control in the settings UI. The settings page dispatches partial updates that are merged with the current settings:
+
+```ts
+interface EditorSettingsProps {
+  values: EditorSettings;
+  onChange: (values: Partial<EditorSettings>) => void;
+}
+
+// Example: font size input
+<input
+  type="number"
+  min={10}
+  max={24}
+  value={values.fontSize}
+  onChange={(e) => onChange({ fontSize: Number(e.target.value) })}
+/>
+
+// Example: feature toggle
+<input
+  type="checkbox"
+  checked={values.typewriterScrolling}
+  onChange={(e) => onChange({ typewriterScrolling: e.target.checked })}
+/>
+```
+
+The partial update pattern (`Partial<EditorSettings>`) allows each control to update only its own field without knowing about other settings.

--- a/src/content/docs/recipes/typewriter-scrolling.mdx
+++ b/src/content/docs/recipes/typewriter-scrolling.mdx
@@ -1,0 +1,140 @@
+---
+title: Typewriter Scrolling
+description: Keep the cursor line centered in the viewport while typing, using a ViewPlugin with requestAnimationFrame and a tolerance zone.
+sidebar_position: 9
+---
+
+# Typewriter Scrolling
+
+Typewriter scrolling keeps the cursor line vertically centered in the editor viewport as the user types, similar to the behavior in writing-focused editors like iA Writer and Obsidian. This recipe shows how to build it as a CodeMirror extension.
+
+## How It Works
+
+The extension uses a `ViewPlugin` that listens for selection and document changes. When the cursor moves outside a tolerance zone around the viewport center, the editor scrolls to re-center it.
+
+```ts
+import { ViewPlugin, ViewUpdate } from "@codemirror/view";
+
+function typewriterScrolling() {
+  return ViewPlugin.fromClass(
+    class {
+      private pendingFrame = 0;
+
+      update(update: ViewUpdate) {
+        if (!update.selectionSet && !update.docChanged) return;
+
+        if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+
+        const view = update.view;
+        const { head } = view.state.selection.main;
+
+        this.pendingFrame = requestAnimationFrame(() => {
+          this.pendingFrame = 0;
+          const coords = view.coordsAtPos(head);
+          if (!coords) return;
+
+          const editorRect = view.dom.getBoundingClientRect();
+          const viewportHeight = editorRect.height;
+          const centerY = editorRect.top + viewportHeight / 2;
+          const cursorY = coords.top;
+
+          // Only scroll if cursor is outside the center third
+          const tolerance = viewportHeight / 6;
+          if (Math.abs(cursorY - centerY) < tolerance) return;
+
+          view.scrollDOM.scrollTo({
+            top: view.scrollDOM.scrollTop + (cursorY - centerY),
+            behavior: "instant",
+          });
+        });
+      }
+
+      destroy() {
+        if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+      }
+    },
+  );
+}
+```
+
+## Key Design Decisions
+
+### requestAnimationFrame
+
+The scroll adjustment runs inside `requestAnimationFrame` rather than synchronously in the `update` method. This prevents layout thrashing -- reading layout properties (like `coordsAtPos` and `getBoundingClientRect`) and then immediately writing (via `scrollTo`) in the same synchronous flow can force the browser to recalculate layout multiple times.
+
+If multiple updates arrive in the same frame, the previous pending frame is cancelled. Only the last update's scroll adjustment runs.
+
+### Tolerance Zone
+
+Without a tolerance zone, the editor would scroll on every single cursor movement, creating a jittery experience. The tolerance is set to one-sixth of the viewport height, meaning the cursor can move within the center third of the viewport without triggering a scroll.
+
+```
+ +--------------------------+
+ |                          |  <- top third (scroll triggers here)
+ |                          |
+ +--------------------------+
+ |                          |  <- center third (no scroll)
+ |       cursor here OK     |
+ +--------------------------+
+ |                          |  <- bottom third (scroll triggers here)
+ |                          |
+ +--------------------------+
+```
+
+### Triggering Conditions
+
+The plugin responds to two conditions:
+
+- **`update.selectionSet`** -- The cursor moved (arrow keys, mouse click, search jump)
+- **`update.docChanged`** -- The document was modified (typing, paste, undo)
+
+Both are needed because typing creates both a document change and a selection change, while clicking only changes the selection.
+
+### Instant Scrolling
+
+The scroll behavior is set to `"instant"` rather than `"smooth"`. Smooth scrolling creates a visible animation that feels sluggish when typing quickly. Instant scrolling keeps the cursor centered without visible delay.
+
+<Note>
+
+If you prefer a gentler feel, you can change `"instant"` to `"smooth"`. However, be aware that rapid keystrokes will queue multiple smooth scroll animations, which can cause the viewport to lag behind the cursor.
+
+</Note>
+
+## Cleanup
+
+The `destroy` method cancels any pending animation frame when the plugin is removed. This prevents a stale callback from running after the editor is destroyed.
+
+```ts
+destroy() {
+  if (this.pendingFrame) cancelAnimationFrame(this.pendingFrame);
+}
+```
+
+## Usage
+
+```ts
+const extensions = [
+  // ... other extensions
+  typewriterScrolling(),
+];
+```
+
+<Tip>
+
+Typewriter scrolling works best with `scrollPastEnd()` from `@codemirror/view`. Without it, the editor cannot scroll the last line to the center of the viewport because there is no content below it to scroll into. `scrollPastEnd()` adds virtual space after the document to enable this.
+
+</Tip>
+
+## Making It Toggleable
+
+In a settings-driven editor, typewriter scrolling should be toggled on and off without recreating the editor. One approach is to conditionally include the extension:
+
+```ts
+const extensions = [
+  // ... other extensions
+  ...(settings.typewriterScrolling ? [typewriterScrolling()] : []),
+];
+```
+
+Alternatively, use a [Compartment](/docs/extensions/compartments/) for runtime reconfiguration.

--- a/src/content/docs/vim-mode/clipboard.mdx
+++ b/src/content/docs/vim-mode/clipboard.mdx
@@ -106,7 +106,11 @@ With this in place, plain `yy` copies to the system clipboard and `p` pastes wha
 
 One limitation of the approach above is that text copied outside the editor (e.g., from another application) is not automatically available for `p`. The internal register only knows about text that was yanked inside the editor.
 
-To handle external clipboard content, read from `navigator.clipboard` when the editor gains focus.
+To handle external clipboard content, read from `navigator.clipboard` when the editor or window gains focus.
+
+### Standard Browser Approach
+
+In a standard web page, listening on the editor's `focus` event works:
 
 ```ts
 view.dom.addEventListener("focus", async () => {
@@ -123,15 +127,55 @@ view.dom.addEventListener("focus", async () => {
 });
 ```
 
+### Tauri / WKWebView: Use `window.focus` Instead
+
 <Warning>
 
-`navigator.clipboard.readText()` requires the page to have clipboard-read permission. In some browsers, this is granted automatically when the document is focused. In others, the user may see a permission prompt. If permission is denied, the catch block silently handles the error.
+In Tauri applications (which use macOS WKWebView), calling `navigator.clipboard.readText()` inside a `focusin` event handler on the editor element triggers the native macOS "Paste" editing menu -- a clipboard permission prompt that appears as a floating menu near the text cursor. This creates a poor user experience because it appears every time the user clicks into the editor.
+
+**Use `window.addEventListener("focus", ...)` instead of `view.dom.addEventListener("focusin", ...)`.**
 
 </Warning>
 
+The `window.focus` event fires when the application window regains focus from another application (e.g., the user Cmd-Tabs back). This is the moment when the system clipboard is most likely to contain new content from an external source.
+
+```ts
+const syncHandler = async () => {
+  try {
+    const text = await navigator.clipboard.readText();
+    if (text && clipboardRegister.keyBuffer.join("\n") !== text) {
+      clipboardRegister.keyBuffer = [text];
+      clipboardRegister.linewise = text.endsWith("\n");
+      clipboardRegister.blockwise = false;
+    }
+  } catch {
+    // clipboard permission denied -- ignore
+  }
+};
+
+window.addEventListener("focus", syncHandler);
+
+// Cleanup when the editor is destroyed
+function teardown() {
+  window.removeEventListener("focus", syncHandler);
+}
+```
+
+Key differences from the standard approach:
+
+- **`window` event, not editor DOM event** -- Avoids triggering the macOS WKWebView clipboard permission prompt
+- **Deduplication check** -- Only updates the register if the clipboard content differs from what is already stored (`keyBuffer.join("\n") !== text`)
+- **Linewise detection** -- Sets `linewise: true` when the clipboard text ends with a newline, which makes `p` paste below the current line (matching vim's linewise paste behavior)
+
+<Note>
+
+`navigator.clipboard.readText()` requires the page to have clipboard-read permission. In some browsers, this is granted automatically when the document is focused. In others, the user may see a permission prompt. If permission is denied, the catch block silently handles the error.
+
+</Note>
+
 ## Complete Implementation
 
-Putting it all together.
+Putting it all together. This version uses `window.focus` for clipboard sync, which is compatible with both standard browsers and Tauri/WKWebView environments.
 
 ```ts
 import { Vim } from "@replit/codemirror-vim";
@@ -180,7 +224,7 @@ function createClipboardRegister() {
   return register;
 }
 
-function setupClipboardIntegration(view: EditorView) {
+function setupClipboardIntegration(editorElement: HTMLElement) {
   const controller = Vim.getRegisterController();
   const registers = controller.registers;
   const clipboardRegister = createClipboardRegister();
@@ -193,20 +237,32 @@ function setupClipboardIntegration(view: EditorView) {
   registers['"'] = clipboardRegister;
   controller.unnamedRegister = clipboardRegister;
 
-  // Sync external clipboard on focus
-  view.dom.addEventListener("focus", async () => {
+  // Sync external clipboard on window focus (NOT editor focusin).
+  // Using focusin triggers the macOS WKWebView "Paste" permission menu.
+  let cancelled = false;
+  const syncHandler = async () => {
+    if (cancelled) return;
     try {
       const text = await navigator.clipboard.readText();
-      if (text) {
+      if (cancelled) return;
+      if (text && clipboardRegister.keyBuffer.join("\n") !== text) {
         clipboardRegister.keyBuffer = [text];
-        clipboardRegister.linewise = false;
+        clipboardRegister.linewise = text.endsWith("\n");
         clipboardRegister.blockwise = false;
       }
     } catch {
       // clipboard-read permission denied
     }
-  });
+  };
+
+  window.addEventListener("focus", syncHandler);
+
+  // Return cleanup function
+  return () => {
+    cancelled = true;
+    window.removeEventListener("focus", syncHandler);
+  };
 }
 ```
 
-Call `setupClipboardIntegration(view)` after creating the EditorView.
+Call `setupClipboardIntegration(view.dom)` after creating the EditorView. Store the returned cleanup function and call it when the editor is destroyed.

--- a/src/content/docs/vim-mode/clipboard.mdx
+++ b/src/content/docs/vim-mode/clipboard.mdx
@@ -224,7 +224,7 @@ function createClipboardRegister() {
   return register;
 }
 
-function setupClipboardIntegration(editorElement: HTMLElement) {
+function setupClipboardIntegration() {
   const controller = Vim.getRegisterController();
   const registers = controller.registers;
   const clipboardRegister = createClipboardRegister();
@@ -265,4 +265,4 @@ function setupClipboardIntegration(editorElement: HTMLElement) {
 }
 ```
 
-Call `setupClipboardIntegration(view.dom)` after creating the EditorView. Store the returned cleanup function and call it when the editor is destroyed.
+Call `setupClipboardIntegration()` after creating the EditorView. Store the returned cleanup function and call it when the editor is destroyed.

--- a/src/content/docs/vim-mode/vimrc.mdx
+++ b/src/content/docs/vim-mode/vimrc.mdx
@@ -174,3 +174,78 @@ if (vimrc) {
   applyVimrc(view, vimrc);
 }
 ```
+
+## File-Based + Settings-Based Vimrc Layering
+
+In a desktop application, you may want to support two vimrc sources:
+
+1. **File-based vimrc** -- A `.vimrc` file on disk, loaded via the backend (e.g., Tauri IPC)
+2. **Settings-based vimrc** -- A vimrc string stored in the application settings UI
+
+The layering strategy applies the file-based vimrc first, then the settings-based vimrc second. This way, settings-based overrides take precedence, and the user can customize behavior without editing the disk file.
+
+```ts
+import { getCM, Vim } from "@replit/codemirror-vim";
+
+async function applyLayeredVimrc(
+  view: EditorView,
+  settingsVimrc: string,
+  readVimrcFromDisk: () => Promise<string | null>,
+) {
+  const cm = getCM(view);
+  if (!cm) return;
+
+  const applyVimrc = (source: string, label: string) => {
+    for (const cmd of parseVimrc(source)) {
+      try {
+        Vim.handleEx(cm, cmd);
+      } catch (e) {
+        console.warn(`${label} vimrc command failed: ${cmd}`, e);
+      }
+    }
+  };
+
+  // Layer 1: file-based vimrc (loaded from disk)
+  const fileVimrc = await readVimrcFromDisk();
+  if (fileVimrc) {
+    applyVimrc(fileVimrc, "file-based");
+  }
+
+  // Layer 2: settings-based vimrc (overrides file-based)
+  if (settingsVimrc) {
+    applyVimrc(settingsVimrc, "settings");
+  }
+}
+```
+
+<Tip>
+
+This layering pattern mirrors how shell configuration works (`/etc/profile` then `~/.profile`). The file-based vimrc provides machine-level defaults, while the settings-based vimrc allows per-application customization through the UI.
+
+</Tip>
+
+### Handling Async Loading
+
+Since file-based vimrc is loaded asynchronously (via file system APIs), the vimrc application happens after the `EditorView` is created. Use a cancellation guard to prevent applying vimrc to a destroyed editor:
+
+```ts
+let cancelled = false;
+
+readVimrcFromDisk().then((vimrcContent) => {
+  if (cancelled) return;
+  const cm = getCM(view);
+  if (!cm) return;
+
+  if (vimrcContent) {
+    applyVimrc(vimrcContent, "file-based");
+  }
+  if (settingsVimrc) {
+    applyVimrc(settingsVimrc, "settings");
+  }
+});
+
+// In cleanup:
+cancelled = true;
+```
+
+This is important in React applications where the editor may be destroyed and recreated before the async vimrc read completes.


### PR DESCRIPTION
## Summary
- Added 8 new documentation articles (English + Japanese) based on CodeMirror patterns from zudo-text
- Updated 2 existing articles with Tauri-specific details

## New Articles
1. `recipes/bracket-colorization.mdx` - Bracket color cycling by nesting depth
2. `recipes/indent-guides.mdx` - Vertical indent guide lines
3. `recipes/typewriter-scrolling.mdx` - Cursor-centered scrolling
4. `recipes/scrollbar-cursor-indicator.mdx` - Cursor position on scrollbar
5. `recipes/markdown-list-handling.mdx` - List continuation + hanging indent
6. `recipes/display-scale-integration.mdx` - Dynamic display scale factor
7. `extensions/palette-theme-integration.mdx` - CSS custom property theming
8. `recipes/settings-driven-editor.mdx` - App settings to CodeMirror config

## Updated Articles
- `vim-mode/vimrc.mdx` - Added file-based vimrc layering
- `vim-mode/clipboard.mdx` - window.focus timing for Tauri

🤖 Generated with [Claude Code](https://claude.com/claude-code)