### PR TITLE
refactor: enhance CLAUDE.md with doc writing and navigation guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,20 +14,116 @@ pnpm format:md    # Format MDX files
 pnpm b4push       # Pre-push validation (cm6 bundle + format + typecheck + build)
 ```
 
-## Content
+## Content Structure
 
-- English (default): `src/content/docs/` → `/docs/...`
-- Japanese: `src/content/docs-ja/` → `/ja/docs/...`
+- English (default): `src/content/docs/` -> `/docs/...`
+- Japanese: `src/content/docs-ja/` -> `/ja/docs/...`
 - Japanese docs mirror the English directory structure
-- Required frontmatter: `title` (string). Optional: `description`, `sidebar_position` (number).
-- When adding/modifying EN content, update the corresponding JA file.
 
-## MDX Components
+**Bilingual rule**: When adding or modifying EN content, update the corresponding JA file. Keep code blocks and `<HtmlPreview>` blocks identical between languages -- only translate surrounding prose. If a Japanese version does not yet exist, create it.
 
-Available globally without imports:
+**Exception**: Pages with `generated: true` in frontmatter (e.g., claude-resources auto-generated pages) do not require Japanese translations.
 
-- `<Note>`, `<Tip>`, `<Info>`, `<Warning>`, `<Danger>` - Admonitions
-- `<HtmlPreview>` - Interactive HTML/CSS/JS preview with code display
+## Content Categories
+
+Top-level directories under `src/content/docs/`. Directories with header nav entries are mapped via `categoryMatch` in `src/config/settings.ts`:
+
+- `overview/` - Introduction and getting started
+- `core/` - Core CodeMirror 6 concepts
+- `vim-mode/` - Vim mode integration
+- `extensions/` - CodeMirror extensions
+- `recipes/` - Real-world patterns and examples
+- `claude/` - Claude Code integration docs
+
+Auto-generated directories (no header nav entry, managed by claude-resources integration):
+
+- `claude-md/` - CLAUDE.md file documentation (`noPage: true`)
+- `claude-skills/` - Claude Skills documentation (`noPage: true`)
+
+## Writing Docs
+
+All documentation files use `.mdx` format with YAML frontmatter.
+
+### Frontmatter Fields
+
+Schema defined in `src/content.config.ts`:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | Yes | Page title, rendered as the page h1 |
+| `description` | string | No | Subtitle displayed below the title |
+| `sidebar_position` | number | No | Sort order within category (lower = higher). Always set this for predictable ordering |
+| `sidebar_label` | string | No | Custom text for sidebar display (overrides `title`) |
+| `tags` | string[] | No | Cross-category grouping tags |
+| `draft` | boolean | No | Exclude from build entirely |
+| `unlisted` | boolean | No | Built but noindexed, hidden from sidebar/nav |
+| `hide_sidebar` | boolean | No | Hide the left sidebar, center content |
+| `hide_toc` | boolean | No | Hide the right-side table of contents |
+| `standalone` | boolean | No | Hidden from sidebar nav but still indexed |
+| `slug` | string | No | Custom URL slug override |
+| `generated` | boolean | No | Build-time generated content (skip translation) |
+| `search_exclude` | boolean | No | Exclude from search results |
+| `pagination_next` | string/null | No | Override next page link (null to hide) |
+| `pagination_prev` | string/null | No | Override prev page link (null to hide) |
+
+### Content Rules
+
+- **No h1 in content**: The frontmatter `title` is automatically rendered as the page h1. Start your content with `## h2` headings. Do not write `# h1` in the MDX body.
+- **Always set `sidebar_position`**: Without it, pages sort alphabetically which is unpredictable. Use integers starting from 1.
+- **Kebab-case file names**: Use `my-article.mdx`, not `myArticle.mdx` or `my_article.mdx`.
+
+### Linking Between Docs
+
+Use relative file paths with the `.mdx` extension:
+
+```markdown
+[Link text](./sibling-page.mdx)
+[Link text](../other-category/page.mdx)
+[Link text](../other-category/page.mdx#anchor)
+```
+
+The remark plugin resolves these during build. External links use standard URLs.
+
+### Admonitions
+
+Available globally without imports. Two syntax forms:
+
+**Directive syntax** (preferred for longer content):
+
+```markdown
+:::note[Custom Title]
+Content here.
+:::
+```
+
+**JSX syntax** (for inline use):
+
+```markdown
+<Note>Short note content.</Note>
+```
+
+Types: `<Note>`, `<Tip>`, `<Info>`, `<Warning>`, `<Danger>`
+
+### Mermaid Diagrams
+
+Mermaid is enabled. Use fenced code blocks:
+
+````markdown
+```mermaid
+graph TB
+  A --> B
+```
+````
+
+### HtmlPreview Component
+
+For interactive HTML/CSS/JS previews with code display:
+
+```markdown
+<HtmlPreview html="<div>Hello</div>" css="div { color: red; }" />
+```
+
+Use `js`/`displayJs` props for JavaScript demos.
 
 ## Live Demos (CM6 Bundle)
 
@@ -36,7 +132,76 @@ Pre-built IIFE bundle at `public/assets/cm6-bundle.min.js` exposes `window.CM` i
 - Rebuild: `pnpm build:cm6` (entry: `scripts/cm6-bundle-entry.ts`)
 - `js` prop: runtime code using `CM.*` globals
 - `displayJs` prop: clean ESM imports shown in "Show code" panel
-- Keep HtmlPreview blocks identical in EN/JA — only translate surrounding text.
+- Keep HtmlPreview blocks identical in EN/JA -- only translate surrounding text.
+
+## Navigation Structure
+
+Navigation is filesystem-driven. Directory structure directly becomes sidebar navigation.
+
+### Sidebar Ordering
+
+- Pages are ordered by `sidebar_position` (ascending). Without it, alphabetical order is used.
+- Category index pages (`index.mdx`) control category position via their own `sidebar_position`.
+
+### Category Index Pages
+
+Create `index.mdx` in a category directory when you want custom intro copy, description, or explicit sidebar ordering. The framework auto-generates category index pages when missing, but explicit ones give better control.
+
+### Category Configuration
+
+Use `_category_.json` for category-level metadata when needed:
+
+```json
+{
+  "label": "Category Name",
+  "position": 900,
+  "description": "Category description",
+  "noPage": true
+}
+```
+
+The `noPage: true` flag means the category has no landing page (just groups items).
+
+### Header Navigation
+
+Defined in `src/config/settings.ts` via `headerNav`. Each item maps to a top-level content directory via `categoryMatch`:
+
+```typescript
+{ label: "Overview", path: "/docs/overview", categoryMatch: "overview" }
+```
+
+`categoryMatch` must be a single top-level directory name. Adding a new header nav item requires editing `settings.ts`.
+
+## Content Creation Workflow
+
+### Adding a New Article
+
+1. Create the English `.mdx` file in the appropriate category under `src/content/docs/`
+2. Add frontmatter with at least `title` and `sidebar_position`
+3. Write content starting with `## h2` headings (not `# h1`)
+4. Create the matching Japanese file under `src/content/docs-ja/` with the same path
+5. Keep code blocks, Mermaid diagrams, and `<HtmlPreview>` blocks identical -- only translate prose
+6. Run `pnpm format:md` to format the MDX files
+7. Run `pnpm build` to verify the site builds correctly
+
+### Adding a New Category
+
+1. Create the directory under `src/content/docs/` (kebab-case)
+2. Create `index.mdx` with `title`, `description`, and `sidebar_position`
+3. Add a `headerNav` entry in `src/config/settings.ts` with `categoryMatch` pointing to the directory name
+4. Mirror the directory structure under `src/content/docs-ja/`
+5. Run `pnpm build` to verify
+
+## Doc Skill (codemirror-wisdom)
+
+The `codemirror-wisdom` skill (`.claude/skills/codemirror-wisdom/SKILL.md`) is **generated** by `pnpm setup:doc-skill` (runs `scripts/setup-doc-skill.sh`). It is gitignored -- do NOT track it in git or edit it directly. To update the skill content, edit the generator script and re-run `pnpm setup:doc-skill`.
+
+## MDX Components
+
+Available globally in MDX without imports:
+
+- `<Note>`, `<Tip>`, `<Info>`, `<Warning>`, `<Danger>` - Admonitions
+- `<HtmlPreview>` - Interactive HTML/CSS/JS preview with code display
 
 ## CI/CD
 

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -90,7 +90,7 @@ argument-hint: "[-u|--update] [topic keyword, e.g., 'configuration', 'sidebar', 
 # $PROJECT_NAME Documentation Reference
 
 Look up documentation from the $PROJECT_NAME project.
-Documentation base path: \`$REPO_ROOT/src/content/docs\`
+Documentation base path: \`src/content/docs\` (relative to repo root)
 
 ## Mode Detection
 
@@ -121,17 +121,22 @@ documentation in this repo.
    the topic. Read them to understand what is already covered.
 3. **Decide create vs update**: If an existing article covers the topic, update
    it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
-4. **Write the content**: Follow the project conventions:
-   - Required frontmatter: \`title\` (string). Optional: \`description\`,
-     \`sidebar_position\` (number).
+4. **Write the content**: Follow the doc-authoring rules in the root CLAUDE.md:
+   - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
+     Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
+   - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.
+     Start with \`## h2\` headings.
    - Use available MDX components (\`<Note>\`, \`<Tip>\`, \`<Info>\`, \`<Warning>\`,
      \`<Danger>\`, \`<HtmlPreview>\`) where appropriate.
    - For live demos, use \`<HtmlPreview>\` with \`js\`/\`displayJs\` props that
      reference \`CM.*\` globals from the pre-built bundle.
+   - Link to other docs using relative paths with \`.mdx\` extension.
 5. **Update Japanese docs**: Create or update the corresponding file under
-   \`docs-ja/\` mirroring the English directory structure. Keep \`<HtmlPreview>\`
-   blocks identical — only translate surrounding text.
+   \`docs-ja/\` mirroring the English directory structure. Keep code blocks,
+   Mermaid diagrams, and \`<HtmlPreview>\` blocks identical — only translate
+   surrounding prose. Exception: pages with \`generated: true\` skip translation.
 6. **Format**: Run \`pnpm format:md\` to format the new/changed MDX files.
+7. **Verify**: Run \`pnpm build\` to confirm the site builds correctly.
 
 ## Documentation Structure
 

--- a/src/content/docs/claude-md/root.mdx
+++ b/src/content/docs/claude-md/root.mdx
@@ -1,8 +1,8 @@
 ---
-title: /CLAUDE.md
-description: CLAUDE.md at /CLAUDE.md
+title: "/CLAUDE.md"
+description: "CLAUDE.md at /CLAUDE.md"
 sidebar_position: 2
-sidebar_label: CLAUDE.md
+sidebar_label: "CLAUDE.md"
 generated: true
 ---
 
@@ -24,20 +24,116 @@ pnpm format:md    # Format MDX files
 pnpm b4push       # Pre-push validation (cm6 bundle + format + typecheck + build)
 ```
 
-## Content
+## Content Structure
 
-- English (default): `src/content/docs/` → `/docs/...`
-- Japanese: `src/content/docs-ja/` → `/ja/docs/...`
+- English (default): `src/content/docs/` -> `/docs/...`
+- Japanese: `src/content/docs-ja/` -> `/ja/docs/...`
 - Japanese docs mirror the English directory structure
-- Required frontmatter: `title` (string). Optional: `description`, `sidebar_position` (number).
-- When adding/modifying EN content, update the corresponding JA file.
 
-## MDX Components
+**Bilingual rule**: When adding or modifying EN content, update the corresponding JA file. Keep code blocks and `<HtmlPreview>` blocks identical between languages -- only translate surrounding prose. If a Japanese version does not yet exist, create it.
 
-Available globally without imports:
+**Exception**: Pages with `generated: true` in frontmatter (e.g., claude-resources auto-generated pages) do not require Japanese translations.
 
-- `<Note>`, `<Tip>`, `<Info>`, `<Warning>`, `<Danger>` - Admonitions
-- `<HtmlPreview>` - Interactive HTML/CSS/JS preview with code display
+## Content Categories
+
+Top-level directories under `src/content/docs/`. Directories with header nav entries are mapped via `categoryMatch` in `src/config/settings.ts`:
+
+- `overview/` - Introduction and getting started
+- `core/` - Core CodeMirror 6 concepts
+- `vim-mode/` - Vim mode integration
+- `extensions/` - CodeMirror extensions
+- `recipes/` - Real-world patterns and examples
+- `claude/` - Claude Code integration docs
+
+Auto-generated directories (no header nav entry, managed by claude-resources integration):
+
+- `claude-md/` - CLAUDE.md file documentation (`noPage: true`)
+- `claude-skills/` - Claude Skills documentation (`noPage: true`)
+
+## Writing Docs
+
+All documentation files use `.mdx` format with YAML frontmatter.
+
+### Frontmatter Fields
+
+Schema defined in `src/content.config.ts`:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | Yes | Page title, rendered as the page h1 |
+| `description` | string | No | Subtitle displayed below the title |
+| `sidebar_position` | number | No | Sort order within category (lower = higher). Always set this for predictable ordering |
+| `sidebar_label` | string | No | Custom text for sidebar display (overrides `title`) |
+| `tags` | string[] | No | Cross-category grouping tags |
+| `draft` | boolean | No | Exclude from build entirely |
+| `unlisted` | boolean | No | Built but noindexed, hidden from sidebar/nav |
+| `hide_sidebar` | boolean | No | Hide the left sidebar, center content |
+| `hide_toc` | boolean | No | Hide the right-side table of contents |
+| `standalone` | boolean | No | Hidden from sidebar nav but still indexed |
+| `slug` | string | No | Custom URL slug override |
+| `generated` | boolean | No | Build-time generated content (skip translation) |
+| `search_exclude` | boolean | No | Exclude from search results |
+| `pagination_next` | string/null | No | Override next page link (null to hide) |
+| `pagination_prev` | string/null | No | Override prev page link (null to hide) |
+
+### Content Rules
+
+- **No h1 in content**: The frontmatter `title` is automatically rendered as the page h1. Start your content with `## h2` headings. Do not write `# h1` in the MDX body.
+- **Always set `sidebar_position`**: Without it, pages sort alphabetically which is unpredictable. Use integers starting from 1.
+- **Kebab-case file names**: Use `my-article.mdx`, not `myArticle.mdx` or `my_article.mdx`.
+
+### Linking Between Docs
+
+Use relative file paths with the `.mdx` extension:
+
+```markdown
+[Link text](./sibling-page.mdx)
+[Link text](../other-category/page.mdx)
+[Link text](../other-category/page.mdx#anchor)
+```
+
+The remark plugin resolves these during build. External links use standard URLs.
+
+### Admonitions
+
+Available globally without imports. Two syntax forms:
+
+**Directive syntax** (preferred for longer content):
+
+```markdown
+:::note[Custom Title]
+Content here.
+:::
+```
+
+**JSX syntax** (for inline use):
+
+```markdown
+<Note>Short note content.</Note>
+```
+
+Types: `<Note>`, `<Tip>`, `<Info>`, `<Warning>`, `<Danger>`
+
+### Mermaid Diagrams
+
+Mermaid is enabled. Use fenced code blocks:
+
+````markdown
+```mermaid
+graph TB
+  A --> B
+```
+````
+
+### HtmlPreview Component
+
+For interactive HTML/CSS/JS previews with code display:
+
+```markdown
+<HtmlPreview html="<div>Hello</div>" css="div { color: red; }" />
+```
+
+Use `js`/`displayJs` props for JavaScript demos.
 
 ## Live Demos (CM6 Bundle)
 
@@ -46,7 +142,76 @@ Pre-built IIFE bundle at `public/assets/cm6-bundle.min.js` exposes `window.CM` i
 - Rebuild: `pnpm build:cm6` (entry: `scripts/cm6-bundle-entry.ts`)
 - `js` prop: runtime code using `CM.*` globals
 - `displayJs` prop: clean ESM imports shown in "Show code" panel
-- Keep HtmlPreview blocks identical in EN/JA — only translate surrounding text.
+- Keep HtmlPreview blocks identical in EN/JA -- only translate surrounding text.
+
+## Navigation Structure
+
+Navigation is filesystem-driven. Directory structure directly becomes sidebar navigation.
+
+### Sidebar Ordering
+
+- Pages are ordered by `sidebar_position` (ascending). Without it, alphabetical order is used.
+- Category index pages (`index.mdx`) control category position via their own `sidebar_position`.
+
+### Category Index Pages
+
+Create `index.mdx` in a category directory when you want custom intro copy, description, or explicit sidebar ordering. The framework auto-generates category index pages when missing, but explicit ones give better control.
+
+### Category Configuration
+
+Use `_category_.json` for category-level metadata when needed:
+
+```json
+{
+  "label": "Category Name",
+  "position": 900,
+  "description": "Category description",
+  "noPage": true
+}
+```
+
+The `noPage: true` flag means the category has no landing page (just groups items).
+
+### Header Navigation
+
+Defined in `src/config/settings.ts` via `headerNav`. Each item maps to a top-level content directory via `categoryMatch`:
+
+```typescript
+{ label: "Overview", path: "/docs/overview", categoryMatch: "overview" }
+```
+
+`categoryMatch` must be a single top-level directory name. Adding a new header nav item requires editing `settings.ts`.
+
+## Content Creation Workflow
+
+### Adding a New Article
+
+1. Create the English `.mdx` file in the appropriate category under `src/content/docs/`
+2. Add frontmatter with at least `title` and `sidebar_position`
+3. Write content starting with `## h2` headings (not `# h1`)
+4. Create the matching Japanese file under `src/content/docs-ja/` with the same path
+5. Keep code blocks, Mermaid diagrams, and `<HtmlPreview>` blocks identical -- only translate prose
+6. Run `pnpm format:md` to format the MDX files
+7. Run `pnpm build` to verify the site builds correctly
+
+### Adding a New Category
+
+1. Create the directory under `src/content/docs/` (kebab-case)
+2. Create `index.mdx` with `title`, `description`, and `sidebar_position`
+3. Add a `headerNav` entry in `src/config/settings.ts` with `categoryMatch` pointing to the directory name
+4. Mirror the directory structure under `src/content/docs-ja/`
+5. Run `pnpm build` to verify
+
+## Doc Skill (codemirror-wisdom)
+
+The `codemirror-wisdom` skill (`.claude/skills/codemirror-wisdom/SKILL.md`) is **generated** by `pnpm setup:doc-skill` (runs `scripts/setup-doc-skill.sh`). It is gitignored -- do NOT track it in git or edit it directly. To update the skill content, edit the generator script and re-run `pnpm setup:doc-skill`.
+
+## MDX Components
+
+Available globally in MDX without imports:
+
+- `<Note>`, `<Tip>`, `<Info>`, `<Warning>`, `<Danger>` - Admonitions
+- `<HtmlPreview>` - Interactive HTML/CSS/JS preview with code display
 
 ## CI/CD
 

--- a/src/content/docs/claude-skills/codemirror-wisdom.mdx
+++ b/src/content/docs/claude-skills/codemirror-wisdom.mdx
@@ -1,21 +1,60 @@
 ---
-title: codemirror-wisdom
-description: Search and reference documentation from the zudo-codemirror project. Use when answering questions about zudo-codemirror features, configuration, components, or usage patterns.
-sidebar_label: codemirror-wisdom
+title: "codemirror-wisdom"
+description: "Search and reference documentation from the zudo-codemirror project. Use when answering questions about zudo-codemirror features, configuration, components, or usage patterns."
+sidebar_label: "codemirror-wisdom"
 generated: true
 ---
 
 # zudo-codemirror Documentation Reference
 
 Look up documentation from the zudo-codemirror project.
-Documentation base path: `/Users/takazudo/repos/wisdom/zudo-codemirror/src/content/docs`
+Documentation base path: `src/content/docs` (relative to repo root)
 
-## How to Use
+## Mode Detection
+
+Parse the argument string for flags:
+
+- If args start with `-u` or `--update`: enter **Update mode** (see below)
+- Otherwise: enter **Lookup mode** (default)
+
+Strip the flag from the remaining argument to get the topic keyword.
+
+## Lookup Mode (default)
 
 1. Find the relevant article(s) from the `docs/` directory based on the topic
 2. Read ONLY the specific article(s) you need — do NOT load all articles at once
 3. Apply the information from the article when answering the user's question
 4. Mention the source article path so the user can find it for further reading
+
+## Update Mode (`-u` / `--update`)
+
+The user has new information about CodeMirror and wants to add or update
+documentation in this repo.
+
+### Workflow
+
+1. **Understand the new info**: Ask the user what they learned or want to
+   document. The topic keyword (if provided) hints at the subject area.
+2. **Find existing docs**: Search the `docs/` directory for articles related to
+   the topic. Read them to understand what is already covered.
+3. **Decide create vs update**: If an existing article covers the topic, update
+   it. Otherwise, create a new `.mdx` file in the appropriate subdirectory.
+4. **Write the content**: Follow the doc-authoring rules in the root CLAUDE.md:
+   - Required frontmatter: `title` (string). Always set `sidebar_position`.
+     Optional: `description`, `sidebar_label`, `tags`, etc.
+   - Do NOT use `# h1` in content — the frontmatter `title` renders as h1.
+     Start with `## h2` headings.
+   - Use available MDX components (`<Note>`, `<Tip>`, `<Info>`, `<Warning>`,
+     `<Danger>`, `<HtmlPreview>`) where appropriate.
+   - For live demos, use `<HtmlPreview>` with `js`/`displayJs` props that
+     reference `CM.*` globals from the pre-built bundle.
+   - Link to other docs using relative paths with `.mdx` extension.
+5. **Update Japanese docs**: Create or update the corresponding file under
+   `docs-ja/` mirroring the English directory structure. Keep code blocks,
+   Mermaid diagrams, and `<HtmlPreview>` blocks identical — only translate
+   surrounding prose. Exception: pages with `generated: true` skip translation.
+6. **Format**: Run `pnpm format:md` to format the new/changed MDX files.
+7. **Verify**: Run `pnpm build` to confirm the site builds correctly.
 
 ## Documentation Structure
 
@@ -23,6 +62,7 @@ The documentation is organized in MDX files under `docs/`:
 
 ```
 - claude-md/
+- claude-skills/
 - claude/
 - core/
 - extensions/

--- a/src/content/docs/claude/index.mdx
+++ b/src/content/docs/claude/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Claude
-description: Claude Code configuration reference.
+title: "Claude"
+description: "Claude Code configuration reference."
 sidebar_position: 899
 generated: true
 ---


### PR DESCRIPTION
## Summary
- Adds comprehensive doc-authoring guidance to CLAUDE.md so AI sessions understand frontmatter conventions, sidebar ordering, admonitions, linking, and content creation workflows
- Adds `generated: true` bilingual exception for auto-generated claude-resources pages
- Documents that codemirror-wisdom skill is generated (not tracked in git)
- Updates setup-doc-skill.sh generator with improved doc-authoring rules and relative path

## Changes

**CLAUDE.md enhancements:**
- Added "Writing Docs" section: complete frontmatter field reference (from `content.config.ts` schema), no-h1 rule, kebab-case naming, relative linking with `.mdx`, admonition syntax (both directive and JSX), Mermaid diagram usage, HtmlPreview component
- Added "Navigation Structure" section: sidebar_position ordering, category index pages, `_category_.json` config, headerNav mapping via `categoryMatch` in settings.ts
- Added "Content Creation Workflow" section: step-by-step for new articles and new categories
- Separated auto-generated directories (claude-md, claude-skills) from nav-linked categories
- Added `generated: true` exception to the bilingual rule
- Added "Doc Skill" section explaining the skill is generated and gitignored

**setup-doc-skill.sh updates:**
- Replaced hard-coded absolute path with repo-relative path for portability
- Updated Update Mode workflow to reference CLAUDE.md doc-authoring rules
- Added no-h1 rule, relative linking, and `generated: true` exception guidance
- Added build verification step (`pnpm build`)

## Test Plan
- [x] `pnpm build` passes (87 pages, no errors)
- [ ] CI checks (typecheck + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)