### PR TITLE
Add OGP banner image and meta tags

### DIFF
--- a/src/layouts/doc-layout.astro
+++ b/src/layouts/doc-layout.astro
@@ -47,6 +47,13 @@ const {
 const latestUrl = currentSlug ? docsUrl(currentSlug, lang) : undefined;
 const versionAvailability = settings.versions ? await getVersionAvailability() : undefined;
 const fullTitle = title === settings.siteName ? title : `${title} | ${settings.siteName}`;
+// Absolute URLs for OGP/Twitter meta. settings.siteUrl is empty in some wisdom
+// repos, so fall back to the shared production origin (takazudomodular.com).
+const siteOrigin = settings.siteUrl
+  ? new URL(settings.siteUrl).origin
+  : "https://takazudomodular.com";
+const ogImageUrl = new URL(withBase("/img/ogp.png"), siteOrigin).href;
+const canonicalUrl = new URL(Astro.url.pathname, siteOrigin).href;
 const navSection = currentSlug ? getNavSectionForSlug(currentSlug) : undefined;
 const currentPath = Astro.url.pathname;
 const htmlColorAttrs = settings.colorMode
@@ -82,6 +89,15 @@ const contentTransition = {
     {!settings.noindex && unlisted && <meta name="robots" content="noindex" />}
     <meta property="og:title" content={fullTitle} />
     {description && <meta property="og:description" content={description} />}
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:image" content={ogImageUrl} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content={settings.siteDescription} />
+    <meta property="og:site_name" content={settings.siteName} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content={ogImageUrl} />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
Wires the shared 1200x630 W banner as the OGP social-share image (adds public/img/ogp.png + the og:image meta tags). Logo and intro untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)