### PR TITLE
feat: add silent variant of setup:doc-skill for non-interactive runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "b4push": "bash scripts/run-b4push.sh",
     "gen:z-index": "node scripts/gen-z-index.mjs",
     "check:z-index": "node scripts/gen-z-index.mjs --check",
-    "setup:doc-skill": "bash scripts/setup-doc-skill.sh"
+    "setup:doc-skill": "bash scripts/setup-doc-skill.sh",
+    "setup:doc-skill-silent": "bash scripts/setup-doc-skill.sh --silent"
   },
   "dependencies": {
     "@takazudo/zfb": "0.1.0-next.51",

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -7,6 +7,17 @@ set -euo pipefail
 # the user-scope skills directory (~/.claude/skills/).
 # ────────────────────────────────────────────────────────
 
+# Parse flags. --silent (alias -y) skips the interactive prompt so the
+# automated/non-interactive flow doesn't fail on EOF under `set -e`.
+SILENT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --silent|-y) SILENT="true" ;;
+    *) echo "Error: unknown argument '$1'"; exit 1 ;;
+  esac
+  shift
+done
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Read project name from package.json (used in the generated SKILL.md description/title text)
@@ -15,12 +26,16 @@ PROJECT_NAME=$(node -e "console.log(require('$ROOT_DIR/package.json').name || 'm
 # entry and CLAUDE.md, which both reference `test-wisdom`. See issue #78.
 DEFAULT_SKILL_NAME="codemirror-wisdom"
 
-# Prompt for skill name
-echo ""
-echo "=== zudo-doc Skill Setup ==="
-echo ""
-read -rp "Skill name [$DEFAULT_SKILL_NAME]: " SKILL_NAME
-SKILL_NAME="${SKILL_NAME:-$DEFAULT_SKILL_NAME}"
+# Prompt for skill name (skipped under --silent: use the pinned default directly)
+if [ -n "$SILENT" ]; then
+  SKILL_NAME="$DEFAULT_SKILL_NAME"
+else
+  echo ""
+  echo "=== zudo-doc Skill Setup ==="
+  echo ""
+  read -rp "Skill name [$DEFAULT_SKILL_NAME]: " SKILL_NAME
+  SKILL_NAME="${SKILL_NAME:-$DEFAULT_SKILL_NAME}"
+fi
 
 # Validate skill name (allow only alphanumeric, hyphens, underscores)
 if [[ ! "$SKILL_NAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then


### PR DESCRIPTION
## Summary

Adds a non-interactive path to the `setup:doc-skill` flow so the automated wisdom-repo tooling can bake the doc-lookup skill symlink without hitting the interactive prompt.

Under `set -euo pipefail`, the existing `read -rp "Skill name [...]"` prompt fails on EOF when run with no tty, breaking automated runs. This adds a silent path that skips the prompt and uses the pinned default.

## Changes

- **`scripts/setup-doc-skill.sh`** — add a `--silent` flag (alias `-y`), parsed by a small argument loop near the top. When present, the `read -rp` prompt is skipped entirely (no stdin read, no question printed) and the pinned `DEFAULT_SKILL_NAME` is used directly. Without the flag, behavior is unchanged (still prompts interactively). `set -euo pipefail` is intact; the rest of the script is unchanged.
- **`package.json`** — add `setup:doc-skill-silent` = `bash scripts/setup-doc-skill.sh --silent`, placed right after `setup:doc-skill`.

## Verification

- `pnpm setup:doc-skill-silent < /dev/null` (no tty) completes with exit 0, prints no prompt, and bakes the global symlink `~/.claude/skills/codemirror-wisdom` using the pinned default name — identical result to answering the interactive prompt with the default.
- Interactive `pnpm setup:doc-skill` still prints the prompt (unchanged).
- Unknown flags are rejected with a non-zero exit.
- `bash -n` syntax check passes; `package.json` remains valid JSON.

The default skill name is unchanged. This same change is applied uniformly across all sibling `*-wisdom` repos (exact flag `--silent` / `-y`, exact script name `setup:doc-skill-silent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)