### PR TITLE
ci: hand off build outputs via artifacts instead of actions/cache

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -75,6 +75,9 @@ jobs:
           path: dist/
           retention-days: 1
           if-no-files-found: error
+          # github.run_id is reused on "Re-run all jobs"; without overwrite the
+          # re-run's upload fails because the artifact name already exists.
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -155,6 +158,8 @@ jobs:
           path: doc-history-out/
           retention-days: 1
           if-no-files-found: error
+          # Rerunnable: github.run_id is reused on "Re-run all jobs".
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job 3: Deploy to Cloudflare Workers (production)

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -7,9 +7,10 @@
 #   4. Merges both build outputs and deploys to Cloudflare Workers
 #   5. Sends IFTTT notification with deploy status
 #
-# Inter-job data sharing uses actions/cache (not upload-artifact) to avoid
-# Actions storage accumulation. Cache keys are scoped to github.run_id so
-# each run gets a fresh, unique cache that won't be reused by other runs.
+# Inter-job data sharing uses upload-artifact/download-artifact with
+# retention-days: 1, scoped to github.run_id. Artifacts (not actions/cache)
+# because cache saves are best-effort and can silently fail, leaving
+# consumers to hard-fail on a cache miss while the producer still goes green.
 #
 # Concurrency: only one production deploy runs at a time.
 # We do NOT cancel in-progress runs -- the earlier deploy should finish.
@@ -67,11 +68,13 @@ jobs:
       - name: Build site
         run: pnpm build
 
-      - name: Cache site build output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload site build output
+        uses: actions/upload-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -100,12 +103,11 @@ jobs:
       - name: Install deps (no scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download dist artifact (built by build-site)
+        uses: actions/download-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run html-validate
         run: pnpm check:html
@@ -146,11 +148,13 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir doc-history-out
 
-      - name: Cache doc history output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload doc history output
+        uses: actions/upload-artifact@v4
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job 3: Deploy to Cloudflare Workers (production)
@@ -165,19 +169,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Restore site build cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download site build artifact
+        uses: actions/download-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
-      - name: Restore doc history cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download doc history artifact
+        uses: actions/download-artifact@v4
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Prepare deploy directory
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -179,11 +179,13 @@ jobs:
       - name: Check links
         run: pnpm check:links
 
-      - name: Cache site build output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload site build output
+        uses: actions/upload-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -211,12 +213,11 @@ jobs:
       - name: Install deps (no scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download dist artifact (built by build-site)
+        uses: actions/download-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run html-validate
         run: pnpm check:html
@@ -257,11 +258,13 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir doc-history-out
 
-      - name: Cache doc history output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload doc history output
+        uses: actions/upload-artifact@v4
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job 4: Deploy preview and comment on PR
@@ -276,19 +279,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Restore site build cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download site build artifact
+        uses: actions/download-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
-      - name: Restore doc history cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download doc history artifact
+        uses: actions/download-artifact@v4
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Prepare dist for deployment
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -186,6 +186,9 @@ jobs:
           path: dist/
           retention-days: 1
           if-no-files-found: error
+          # github.run_id is reused on "Re-run all jobs"; without overwrite the
+          # re-run's upload fails because the artifact name already exists.
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -265,6 +268,8 @@ jobs:
           path: doc-history-out/
           retention-days: 1
           if-no-files-found: error
+          # Rerunnable: github.run_id is reused on "Re-run all jobs".
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job 4: Deploy preview and comment on PR


### PR DESCRIPTION
## Summary

Both `pr-checks.yml` and `main-deploy.yml` passed build outputs (`dist/`, `doc-history-out/`) between jobs in the same run via the Actions **cache** backend — `actions/cache/save` on producers (keyed `dist-${{ github.run_id }}` / `doc-history-${{ github.run_id }}`) and `actions/cache/restore` with `fail-on-cache-miss: true` on consumers.

Cache saves are best-effort/non-fatal: when the cache backend rejects a save the producing job still goes green, but every consumer then hard-fails on `fail-on-cache-miss`. This broke real deploys.

This PR switches the intra-run hand-off to **artifacts** (`actions/upload-artifact@v4` / `actions/download-artifact@v4`), which is the correct intra-run mechanism and does not touch the cache backend.

## Changes

- **Producers** (`actions/cache/save` → `actions/upload-artifact@v4`): `build-site` (dist) and `build-history` (doc-history) in both workflows.
  - Artifact `name` = the old cache key verbatim (`dist-${{ github.run_id }}` / `doc-history-${{ github.run_id }}`), same `path:`.
  - `retention-days: 1` (preserves the original intent of avoiding Actions storage accumulation).
  - `if-no-files-found: error` (fail loudly if the build produced nothing).
  - `overwrite: true` — `github.run_id` is reused on "Re-run all jobs", and `upload-artifact@v4` rejects a duplicate artifact name within a run; without this a re-run would fail at the upload step.
- **Consumers** (`actions/cache/restore` → `actions/download-artifact@v4`): `html-validate` + `deploy` (main) / `html-validate` + `preview` (PR).
  - Artifact `name` = old cache key verbatim, same `path:`; dropped `key:` and `fail-on-cache-miss:` (invalid for download-artifact — it already fails if the artifact is missing).
- Rewrote the top-of-file comment in `main-deploy.yml` describing the inter-job hand-off (now artifacts, with the rationale).

Round-trip layout is preserved (`upload path: dist/` → `download path: dist/` restores to `dist/`, not `dist/dist/`). Nothing else changed — build/deploy/secrets/concurrency/`needs:`/html-validate command/wrangler/IFTTT steps are untouched.

## Test Plan

- This PR's `pr-checks` run exercises the new `pr-checks.yml` (Build Site → Upload → html-validate / preview Download must pass).
- Post-merge Production Deploy on `main` exercises `main-deploy.yml`.