### PR TITLE
chore: bump zfb to next.99, re-sync canonical lints, add category-meta CI job

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -110,6 +110,28 @@ jobs:
         run: pnpm format:md:check
 
   # ---------------------------------------------------------------------------
+  # Job 0.7: Category metadata check
+  # ---------------------------------------------------------------------------
+  # Pure-Node script — reads src/ and src/config/settings.ts only, no pnpm
+  # install and no build needed.
+  # Catches two silent failures nothing else here can see: a surviving
+  # _category_.json (zudo-doc cannot read it under zfb, so its label/position/
+  # description/noPage are discarded with a green build) and a headerNav entry
+  # pointing at a `category_no_page: true` page, which 404s site-wide without
+  # tripping check:links --strict-broken.
+  check-category-meta:
+    name: Category Metadata Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Check category metadata
+        run: node scripts/check-category-meta.mjs
+
+  # ---------------------------------------------------------------------------
   # Job 1: Type checking
   # ---------------------------------------------------------------------------
   typecheck:

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "setup:doc-skill:both": "SKILL_NAME=codemirror-wisdom bash scripts/setup-doc-skill.sh --target both"
   },
   "dependencies": {
-    "@takazudo/zfb": "0.1.0-next.89",
-    "@takazudo/zfb-runtime": "0.1.0-next.89",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.89",
-    "@takazudo/zfb-md-wasm": "0.1.0-next.89",
+    "@takazudo/zfb": "0.1.0-next.99",
+    "@takazudo/zfb-runtime": "0.1.0-next.99",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.99",
+    "@takazudo/zfb-md-wasm": "0.1.0-next.99",
     "@takazudo/zudo-doc": "^4.4.13",
     "@takazudo/zudo-doc-history-server": "^4.4.13",
     "@takazudo/zdtp": "0.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,20 +15,20 @@ importers:
         specifier: 0.4.9
         version: 0.4.9(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.89
-        version: 0.1.0-next.89
+        specifier: 0.1.0-next.99
+        version: 0.1.0-next.99
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.89
-        version: 0.1.0-next.89
+        specifier: 0.1.0-next.99
+        version: 0.1.0-next.99
       '@takazudo/zfb-md-wasm':
-        specifier: 0.1.0-next.89
-        version: 0.1.0-next.89
+        specifier: 0.1.0-next.99
+        version: 0.1.0-next.99
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.89
-        version: 0.1.0-next.89(@takazudo/zfb@0.1.0-next.89)
+        specifier: 0.1.0-next.99
+        version: 0.1.0-next.99(@takazudo/zfb@0.1.0-next.99)
       '@takazudo/zudo-doc':
         specifier: ^4.4.13
-        version: 4.4.13(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.4.13)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(zod@4.4.3)
+        version: 4.4.13(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.99)(@takazudo/zfb-runtime@0.1.0-next.99(@takazudo/zfb@0.1.0-next.99))(@takazudo/zfb@0.1.0-next.99)(@takazudo/zudo-doc-history-server@4.4.13)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(zod@4.4.3)
       '@takazudo/zudo-doc-history-server':
         specifier: ^4.4.13
         version: 4.4.13
@@ -1311,52 +1311,52 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.89':
-    resolution: {integrity: sha512-DPKPaL7ytjhrCOlWqqGea4nVgLbhle7HdKlwx118oBM9hu53eHl2Cww2/JZqKMDwmkaTzKVI4y8babOexepnig==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.99':
+    resolution: {integrity: sha512-DJHPHxcc3xpXi0pY3+Wa85BRvaZifFI0vJZ2VxvqfWmK6j3Gxl8Uh03YHGRV/Hzx3my8Ki27qjgVhxAI1aAhrw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.89':
-    resolution: {integrity: sha512-zJjugYxLGfqM8FPapJLx42KgZD5+Z+gxqjmAK3YhtbO6x8sRoVZQwODfsPBqozOB75vv0Qwr9YqmMlR58ScV0A==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.99':
+    resolution: {integrity: sha512-pGB1tBOYSiNfCxPewE19iTVOMlJi1b7cWai7P3e/Q8YoeXvpA+bg1aP6JsFmhlfkARk8N/EIpBKJ2TdawS2lmA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.89':
-    resolution: {integrity: sha512-hJZmGdh2AM/KehijWa2PZWSwzvv/gQFkaLwnvook0UWlHVxcSTyQ/vvJnls+h71thZ0Y4HBYqyjz9JLZ44eIYA==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.99':
+    resolution: {integrity: sha512-UwglM04XmxrS0kiBvEzTnUUDsEqxak5rB6B/6J+WVtRHmpyRpYmqD4lTmHs35OjMgP0Xj3VjA1Twfkqpw38ByA==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.89':
-    resolution: {integrity: sha512-byl6MxCNdNf5rMVZcK22P9cdelNswsUyGuK0TleVatH5ZlWcWzRPAw6xnNqoOp8Vi4NvL/IvlMMebMHlu3UZBQ==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.99':
+    resolution: {integrity: sha512-M1Kymo9raU4oI6AaBV8IKX9TQW07MmuHcWK0gMWiTF/FsM725JkD78gpnl4SdbKqfyJCc83l8WDY97Z/yLjFLA==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.89':
-    resolution: {integrity: sha512-U6qIsX0nR0Utjuoaw+aeSvgPwpH1hgeSEfgtBz9GgxHmh9CR1fN7QCz+OlRH/cOZmGbnqCkyPekdU3BaIV3/3A==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.99':
+    resolution: {integrity: sha512-JuYzJtmVfIst+RH8hqjL5/dz0nL2zkqWz7bTZ6X2j1SYvdZhMrB1A4n4sRH5x4Ihv3eDwjEahz7TJmhK6mjTjA==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-md-wasm@0.1.0-next.89':
-    resolution: {integrity: sha512-vVmKCyQMQ5I5WMSLwXvLYaUb6ac2DJw4FguiQWsA36LCccTBjS7F8PrpOSdDmIY4+ujshIdKiR0SddCGGjs8vg==}
+  '@takazudo/zfb-md-wasm@0.1.0-next.99':
+    resolution: {integrity: sha512-wKA3JE5MpdIhSzgCY+6FkBoJq1zd459oywVzPclk3D6XHO/RLjmvhPfTeQyNB2R2vT9z0ATY2lrYNNPpZ4BUww==}
     engines: {node: '>=20.0.0', pnpm: '>=10.0.0'}
 
-  '@takazudo/zfb-runtime@0.1.0-next.89':
-    resolution: {integrity: sha512-lQuJ65mmydyMulGT0bugFuRRLk+qGfQUAfqWNZsLxF5012ZL+L4ZEELBzzfA+oKlXrfi2HTzbmEChLC4I7X9iA==}
+  '@takazudo/zfb-runtime@0.1.0-next.99':
+    resolution: {integrity: sha512-X6WfSImstjKJoFXtsfQBC0/AdVH0lfFm6zjmM9xAg6j/fwLgXBlen2ZeLGIaHNt4nsTvTfbwoUAq++ltE68+4A==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.89
+      '@takazudo/zfb': 0.1.0-next.99
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.89':
-    resolution: {integrity: sha512-zgjKX9EaL6QD4PSs3qrDSSnpRSzt2RiGOeb5zJeeGVaiu4tyRmnjb/0XcLPq3eyw6yU/j6emUJ2dI6mKsbLD/Q==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.99':
+    resolution: {integrity: sha512-9/Uocff82fAClQVGo5uPzgvvks5+U2NvHDWpEEL92PatfP+9LLInBoEOGqrr7i5TtL+mq9T6JCodthHFitg+WQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.89':
-    resolution: {integrity: sha512-ptxbO8k+Y3mrXek8oT/2OZsd24QP4RKcwUgz6bZwWsKMKRXaw8k8ojPGSY0EVRcVLqrt17jxwaN3XS2Qp51YrA==}
+  '@takazudo/zfb@0.1.0-next.99':
+    resolution: {integrity: sha512-h4iAmYwFq8/vvS9256PzWyVGBJ2dVRJ1J3IB7SvexxDFrHWuM4cK9Gp+J/IUMS5mYlv0dSI6q4c8zrqBtVnzoQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -1496,6 +1496,12 @@ packages:
   '@types/diff@8.0.0':
     resolution: {integrity: sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==}
     deprecated: This is a stub types definition. diff provides its own type definitions, so you do not need this installed.
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
@@ -2120,6 +2126,18 @@ packages:
 
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -3708,45 +3726,51 @@ snapshots:
       preact: 10.29.2
       tailwind-merge: 3.6.0
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.89': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.99': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.89':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.99':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.89':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.99':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.89':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.99':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.89':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.99':
     optional: true
 
-  '@takazudo/zfb-md-wasm@0.1.0-next.89': {}
-
-  '@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89)':
+  '@takazudo/zfb-md-wasm@0.1.0-next.99':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.89
+      '@types/mdast': 4.0.4
+      mdast-util-directive: 3.1.0
+      mdast-util-mdx: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@takazudo/zfb-runtime@0.1.0-next.99(@takazudo/zfb@0.1.0-next.99)':
+    dependencies:
+      '@takazudo/zfb': 0.1.0-next.99
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.89':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.99':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.89':
+  '@takazudo/zfb@0.1.0-next.99':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.89
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.89
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.89
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.89
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.89
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.99
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.99
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.99
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.99
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.99
 
   '@takazudo/zudo-doc-history-server@4.4.13': {}
 
-  '@takazudo/zudo-doc@4.4.13(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.4.13)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(zod@4.4.3)':
+  '@takazudo/zudo-doc@4.4.13(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.99)(@takazudo/zfb-runtime@0.1.0-next.99(@takazudo/zfb@0.1.0-next.99))(@takazudo/zfb@0.1.0-next.99)(@takazudo/zudo-doc-history-server@4.4.13)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(zod@4.4.3)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@22.19.21)
-      '@takazudo/zfb': 0.1.0-next.89
-      '@takazudo/zfb-runtime': 0.1.0-next.89(@takazudo/zfb@0.1.0-next.89)
+      '@takazudo/zfb': 0.1.0-next.99
+      '@takazudo/zfb-runtime': 0.1.0-next.99(@takazudo/zfb@0.1.0-next.99)
       fs-extra: 11.3.5
       gray-matter: 4.0.3
       minimist: 1.2.8
@@ -3758,7 +3782,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@takazudo/zdtp': 0.4.9(preact@10.29.2)
-      '@takazudo/zfb-md-wasm': 0.1.0-next.89
+      '@takazudo/zfb-md-wasm': 0.1.0-next.99
       '@takazudo/zudo-doc-history-server': 4.4.13
       diff: 8.0.4
       katex: 0.16.47
@@ -3894,6 +3918,12 @@ snapshots:
   '@types/diff@8.0.0':
     dependencies:
       diff: 8.0.4
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
+  '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
 
@@ -4538,6 +4568,55 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 

--- a/scripts/check-category-meta.mjs
+++ b/scripts/check-category-meta.mjs
@@ -27,27 +27,49 @@
  *   1. FAIL on any `_category_.json` under src/. Upstream retired the sidecar in
  *      favour of index.mdx frontmatter; any remaining file is dead weight that
  *      reads as configuration but is silently ignored.
- *   2. FAIL when a `headerNav` entry targets a page with
- *      `category_no_page: true`. Suppressing a category that the header links to
- *      turns that link into a site-wide 404, and zfb's `--strict-broken` does
- *      NOT catch it (measured on the zfb docs site).
+ *   2. FAIL when a `headerNav` entry targets a page with `category_no_page:
+ *      true`, in the default locale OR in any configured locale. Suppressing a
+ *      category the header links to turns that link into a site-wide 404, and
+ *      zfb's `--strict-broken` does NOT catch it.
  *
- * Unresolvable headerNav paths are reported as warnings, not failures — the
- * path→file resolution below is a heuristic and must never fail a build on its
- * own uncertainty.
+ * ── A NOTE ON SELF-DEFEAT ─────────────────────────────────────────────────
+ * The first version of this script printed a green OK on a repo where it had
+ * parsed ZERO nav entries, because that repo declares `headerNav` in
+ * src/config/settings.ts and spreads it into zfb.config.ts — so the regex found
+ * nothing and "checked everything successfully" was indistinguishable from
+ * "checked nothing". A guard against silent false-greens that itself
+ * false-greens is worse than no guard, because it manufactures confidence.
+ *
+ * Two rules follow, and both must be preserved by anyone editing this file:
+ *   - ALWAYS report the counts actually inspected (sidecars scanned, nav entries
+ *     parsed, locales considered). A reader must be able to see "0 checked".
+ *   - Treat "found no headerNav at all" as a WARNING worth printing loudly, not
+ *     as success. Absence of findings is not evidence of correctness.
+ *
+ * Unresolvable nav paths are warnings, not failures — the path→file resolution
+ * is a heuristic and must not fail a build on its own uncertainty.
  *
  * Usage: node scripts/check-category-meta.mjs
  * Exit:  0 = OK (warnings allowed), 1 = violations found
  */
 
 import { readFile, readdir, access } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+// fileURLToPath, not .pathname — the latter keeps percent-escapes, so a checkout
+// under a path with spaces or non-ASCII silently resolves to a directory that
+// does not exist, walk() swallows the ENOENT, and the script exits 0 having
+// scanned nothing.
+const ROOT = fileURLToPath(new URL("..", import.meta.url)).replace(/[/\\]$/, "");
 const SRC = join(ROOT, "src");
 const CONFIG = join(ROOT, "zfb.config.ts");
+// headerNav may live directly in zfb.config.ts or in a settings module that the
+// config spreads. Both shapes exist across the wisdom repos.
+const CONFIG_SOURCES = [CONFIG, join(ROOT, "src", "config", "settings.ts")];
 
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", ".astro", ".zfb", ".zfb-build"]);
+const PAGE_EXTS = [".mdx", ".md"];
 
 async function exists(p) {
   try {
@@ -82,14 +104,22 @@ function frontmatter(source) {
   return m ? m[1] : "";
 }
 
+/**
+ * YAML truthiness for `category_no_page`. Accepts the spellings a YAML parser
+ * treats as true — `true`, `True`, `TRUE`, `yes`, `on` — and tolerates a
+ * trailing `# comment`. The original `:\s*true\s*$` form missed all of these
+ * and false-greened on exactly the dead nav link this check exists to catch.
+ */
 function hasNoPage(fm) {
-  return /^\s*category_no_page\s*:\s*true\s*$/m.test(fm);
+  const m = fm.match(/^\s*category_no_page\s*:\s*([^#\r\n]*)/m);
+  if (!m) return false;
+  return /^(true|yes|on)$/i.test(m[1].trim());
 }
 
 /**
- * Pull `path:` values out of the `headerNav: [ ... ]` array in zfb.config.ts.
- * Regex rather than a TS parse: the config is a plain literal in every wisdom
- * repo, and this script must stay dependency-free.
+ * Pull `path:` values out of a `headerNav: [ ... ]` array. Regex rather than a
+ * TS parse: the configs are plain literals and this script stays dependency-free.
+ * Returns [] when the file declares no headerNav.
  */
 function parseHeaderNav(source) {
   const start = source.indexOf("headerNav:");
@@ -109,8 +139,7 @@ function parseHeaderNav(source) {
     }
   }
   if (end === -1) return [];
-  const block = source.slice(open, end);
-  return [...block.matchAll(/path\s*:\s*["'`]([^"'`]+)["'`]/g)].map((m) => m[1]);
+  return [...source.slice(open, end).matchAll(/path\s*:\s*["'`]([^"'`]+)["'`]/g)].map((m) => m[1]);
 }
 
 function parseDocsDir(source) {
@@ -123,12 +152,55 @@ function parseBase(source) {
   return m ? m[1] : "/";
 }
 
+/**
+ * Parse `locales: { ja: { label: "JA", dir: "src/content/docs-ja" }, ... }`.
+ * A locale-only `category_no_page` suppresses that locale's route while the
+ * localized header link survives — the headline failure mode, and one the
+ * default-docsDir-only resolution was completely blind to.
+ */
+function parseLocales(source) {
+  const start = source.indexOf("locales:");
+  if (start === -1) return [];
+  const open = source.indexOf("{", start);
+  if (open === -1) return [];
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) return [];
+  const block = source.slice(open, end);
+  return [...block.matchAll(/(\w+)\s*:\s*\{[^}]*?\bdir\s*:\s*["']([^"']+)["']/g)].map((m) => ({
+    locale: m[1],
+    dir: m[2],
+  }));
+}
+
 const failures = [];
 const warnings = [];
+const notes = [];
 
 // ── Check 1: no _category_.json sidecars ──────────────────────────────────
 const srcFiles = await walk(SRC);
-const sidecars = srcFiles.filter((f) => f.endsWith("/_category_.json"));
+// sep-aware so this also matches on Windows backslash paths.
+const sidecars = srcFiles.filter(
+  (f) => f.endsWith(`${sep}_category_.json`) || f.endsWith("/_category_.json"),
+);
+
+if (srcFiles.length === 0) {
+  warnings.push(
+    `[EMPTY-SCAN] no files found under ${relative(ROOT, SRC)}/ — the sidecar ` +
+      `check inspected nothing. Verify the repo layout; this is not a pass.`,
+  );
+}
+notes.push(`scanned ${srcFiles.length} source file(s) under ${relative(ROOT, SRC)}/`);
 
 for (const f of sidecars) {
   failures.push(
@@ -140,62 +212,106 @@ for (const f of sidecars) {
 }
 
 // ── Check 2: headerNav must not target a suppressed category ──────────────
-if (await exists(CONFIG)) {
-  const configSource = await readFile(CONFIG, "utf-8");
-  const navPaths = parseHeaderNav(configSource);
-  const docsDir = parseDocsDir(configSource);
-  const base = parseBase(configSource);
+let navPaths = [];
+let navSource = null;
+let docsDir = "src/content/docs";
+let base = "/";
+let locales = [];
 
-  for (const navPath of navPaths) {
-    // Strip the configured base prefix, then the leading route segment
-    // (`/docs`), leaving the docsDir-relative slug.
-    let slug = navPath;
-    if (base && base !== "/" && slug.startsWith(base)) slug = slug.slice(base.length);
-    slug = slug.replace(/^\/+/, "").replace(/\/+$/, "");
-    if (slug === "docs") slug = "";
-    else if (slug.startsWith("docs/")) slug = slug.slice("docs/".length);
+for (const candidate of CONFIG_SOURCES) {
+  if (!(await exists(candidate))) continue;
+  const source = await readFile(candidate, "utf-8");
+  if (docsDir === "src/content/docs") docsDir = parseDocsDir(source);
+  if (base === "/") base = parseBase(source);
+  if (locales.length === 0) locales = parseLocales(source);
+  const found = parseHeaderNav(source);
+  if (found.length > 0 && navPaths.length === 0) {
+    navPaths = found;
+    navSource = candidate;
+  }
+}
 
-    const candidates = slug
-      ? [join(ROOT, docsDir, slug, "index.mdx"), join(ROOT, docsDir, `${slug}.mdx`)]
-      : [join(ROOT, docsDir, "index.mdx")];
+if (navPaths.length === 0) {
+  warnings.push(
+    `[NO-NAV] no headerNav entries found in ${CONFIG_SOURCES.map((c) => relative(ROOT, c)).join(" or ")}. ` +
+      `The headerNav→suppressed-category check inspected ZERO links. If this ` +
+      `site does define a header nav, it is declared somewhere this script does ` +
+      `not look and the check is a no-op — fix the canonical script in ` +
+      `wisdom-tweaker/shared/scripts/ rather than ignoring this warning.`,
+  );
+} else {
+  notes.push(
+    `parsed ${navPaths.length} headerNav entr(ies) from ${relative(ROOT, navSource)}`,
+  );
+}
+notes.push(
+  locales.length > 0
+    ? `checking ${locales.length + 1} locale dir(s): ${docsDir}, ${locales.map((l) => l.dir).join(", ")}`
+    : `checking 1 locale dir: ${docsDir}`,
+);
 
+/** Candidate source files for a nav slug within one content dir. */
+function candidatesFor(dir, slug) {
+  const out = [];
+  for (const ext of PAGE_EXTS) {
+    if (slug) {
+      out.push(join(ROOT, dir, slug, `index${ext}`));
+      out.push(join(ROOT, dir, `${slug}${ext}`));
+    } else {
+      out.push(join(ROOT, dir, `index${ext}`));
+    }
+  }
+  return out;
+}
+
+for (const navPath of navPaths) {
+  let slug = navPath;
+  if (base && base !== "/" && slug.startsWith(base)) slug = slug.slice(base.length);
+  slug = slug.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (slug === "docs") slug = "";
+  else if (slug.startsWith("docs/")) slug = slug.slice("docs/".length);
+
+  // Check the default locale and every configured locale — a suppressed JA
+  // page behind a surviving JA header link is just as much a 404.
+  const targets = [{ locale: "(default)", dir: docsDir }, ...locales];
+  let resolvedAnywhere = false;
+
+  for (const t of targets) {
     let resolved = null;
-    for (const c of candidates) {
+    for (const c of candidatesFor(t.dir, slug)) {
       if (await exists(c)) {
         resolved = c;
         break;
       }
     }
+    if (!resolved) continue;
+    resolvedAnywhere = true;
 
-    if (!resolved) {
-      warnings.push(
-        `[UNRESOLVED] headerNav "${navPath}" — could not resolve to a source ` +
-          `file under ${docsDir}/. Verify the link manually; this check could ` +
-          `not.`,
-      );
-      continue;
-    }
-
-    const fm = frontmatter(await readFile(resolved, "utf-8"));
-    if (hasNoPage(fm)) {
+    if (hasNoPage(frontmatter(await readFile(resolved, "utf-8")))) {
       failures.push(
-        `[NAV-404] headerNav "${navPath}" targets ${relative(ROOT, resolved)}, ` +
-          `which sets category_no_page: true. That page is never emitted, so ` +
-          `the header link 404s site-wide. Remove the nav entry or drop ` +
-          `category_no_page.`,
+        `[NAV-404] headerNav "${navPath}" targets ${relative(ROOT, resolved)} ` +
+          `(locale ${t.locale}), which sets category_no_page. That page is ` +
+          `never emitted, so the header link 404s. Remove the nav entry or ` +
+          `drop category_no_page.`,
       );
     }
   }
-} else {
-  warnings.push(`[NO-CONFIG] ${relative(ROOT, CONFIG)} not found — headerNav check skipped.`);
+
+  if (!resolvedAnywhere) {
+    warnings.push(
+      `[UNRESOLVED] headerNav "${navPath}" — no source file found in any ` +
+        `content dir. Verify this link manually; the check could not.`,
+    );
+  }
 }
 
 // ── Report ────────────────────────────────────────────────────────────────
+// Counts always print, so "checked nothing" can never masquerade as "all good".
+for (const n of notes) console.log(`  · ${n}`);
 for (const w of warnings) console.warn(`  ⚠️  ${w}`);
 
 if (failures.length === 0) {
-  const scanned = sidecars.length === 0 ? "no sidecars" : `${sidecars.length} sidecars`;
-  console.log(`OK — category metadata check passed (${scanned}).`);
+  console.log(`OK — category metadata check passed (${sidecars.length} sidecar(s) found).`);
   process.exit(0);
 }
 

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -30,6 +30,14 @@ const __dirname = dirname(__filename);
 const ROOT_DIR = resolve(__dirname, "..");
 const ROOT_PKG_PATH = resolve(ROOT_DIR, "package.json");
 
+// CANONICAL COPY: wisdom-tweaker/shared/scripts/. Distributed verbatim to every
+// *-wisdom repo. Edit here, then re-sync — do not patch a single repo's copy.
+//
+// zfb-md-wasm belongs in this list: it is versioned in lockstep with the rest of
+// the zfb family and zudo-doc peer-requires it at the same range. It was omitted
+// originally, so a stale md-wasm passed the guard silently — which is exactly
+// the failure this check exists to prevent, and it went unnoticed until the
+// family moved off next.89.
 const ZFB_PACKAGES = [
   "@takazudo/zfb",
   "@takazudo/zfb-runtime",


### PR DESCRIPTION
## Summary

Completes the zudo-doc 4.4.13 upgrade begun in #43. Three parts.

**1. Canonical lint re-sync — fixes #44.** Both shared guards re-copied byte-for-byte from `wisdom-tweaker/shared/scripts/`, keeping all five wisdom repos identical.

The v1 `check-category-meta.mjs` regex-scanned `zfb.config.ts` for a literal `headerNav:`. This repo declares nav in `src/config/settings.ts`, so v1 parsed **zero** entries, skipped the NAV-404 check entirely, and still printed a green OK — a guard that reported nothing was indistinguishable from a guard that found nothing wrong. v2 resolves the settings module, checks every configured locale dir, and prints the counts it actually inspected.

Verified locally and in CI:

```
· scanned 88 source file(s) under src/
· parsed 6 headerNav entr(ies) from src/config/settings.ts
· checking 2 locale dir(s): src/content/docs, src/content/docs-ja
OK — category metadata check passed (0 sidecar(s) found).
```

`check-pin-parity.mjs` picks up the canonical header comment. Note its `ZFB_PACKAGES` list **already** included `@takazudo/zfb-md-wasm` in this repo, so the omission that motivated the upstream fix was not present here.

**2. zfb family → `0.1.0-next.99`.** All four move together. zudo-doc 4.4.13 peer-requires `@takazudo/zfb ^0.1.0-next.99`, so the declared peer set is now satisfied rather than merely tolerated — the mismatch flagged in #43 is resolved.

Lockfile-verified resolved versions:

| package | version |
|---|---|
| `@takazudo/zfb` | 0.1.0-next.99 |
| `@takazudo/zfb-runtime` | 0.1.0-next.99 |
| `@takazudo/zfb-adapter-cloudflare` | 0.1.0-next.99 |
| `@takazudo/zfb-md-wasm` | 0.1.0-next.99 |
| `@takazudo/zudo-doc` | 4.4.13 |
| `@takazudo/zudo-doc-history-server` | 4.4.13 |
| `create-zudo-doc` | 4.4.13 |
| `@takazudo/zdtp` | 0.4.9 (untouched) |

Two expectations that did **not** materialise, both confirmed rather than assumed: the **wrangler pin needed no change** (the next.99 platform binary still expects the pinned `4.85.0`), and **template drift was unchanged** against the 4.4.13 baseline.

**3. Category Metadata CI job — closes #45.** Every other b4push check had a CI job; this one did not, so the guard ran only when someone remembered `pnpm b4push` locally. Mirrors `check-pin-parity` (pure-Node, checkout only, no install).

## Runtime smoke test

A 10-release zfb jump is unexercised and this repo has live CodeMirror islands, so this was verified in a real browser against `pnpm preview`, not just the build:

| URL | result |
|---|---|
| `/` | 200, 0 console errors, 0 failed requests |
| `/docs/overview/` | 200, 0 page errors, 0 failed requests |
| `/docs/extensions/compartments/` | 200, 0 page errors, 0 failed requests |

The editors mount inside sandboxed `html-preview` iframes, so they were inspected there directly: **2/2 iframes** have `window.CM` defined and a mounted `.cm-editor` + `.cm-content`, rendering real content (11 and 10 `.cm-line`s, non-zero dimensions).

Interactivity confirmed rather than inferred — clicking the demo's "Toggle Line Numbers" button dispatched a live compartment reconfigure: the `.cm-lineNumbers` gutter went 1 → 0 and the editor stayed mounted. `EditorView.dispatch` and `Compartment.reconfigure` both work on next.99.

The only console output anywhere was Chromium's benign `allow-scripts`/`allow-same-origin` iframe-sandbox warning, which is pre-existing and unrelated to zfb.

## Test Plan

- `pnpm b4push` — **all 9 steps green**, no `B4PUSH_SKIP_*`.
- CI — **9/9 pass**, including the new Category Metadata Check.
- Runtime smoke test — above.