### PR TITLE
chore: re-sync canonical lints to v3, retire wide-home workaround

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -10,8 +10,14 @@
 # v4 template file set that check:template-drift compares against is small:
 #   base:    pages/index.tsx, pages/docs/[[...slug]].tsx,
 #            scripts/setup-doc-skill.sh, src/styles/global.css, tsconfig.json
-# scripts/setup-doc-skill.sh and tsconfig.json are kept byte-identical to the
-# v4 templates (no entry needed). The 4.2.1 -> 4.4.13 bump changed only
+# scripts/setup-doc-skill.sh, tsconfig.json, and pages/index.tsx are kept
+# byte-identical to the v4 templates (no entry needed). pages/index.tsx was
+# allowlisted until zudo-doc 4.4.x: the host reconstructed it purely to pass
+# `wide` to HomePageView, which 4.2.1 exposed no config toggle for
+# (zudolab/zudo-doc#2959). 4.4.13 ships `home: { wide: true }`, so the override
+# was retired, the file is back to the stock 1-line re-export, and the entry
+# was removed rather than left as permanent drift.
+# The 4.2.1 -> 4.4.13 bump changed only
 # setup-doc-skill.sh upstream (a worktree-awareness fix: build/CLAUDE.md paths
 # now resolve to the MAIN project dir rather than the current worktree), which
 # the host had never customized, so the new template version was adopted
@@ -36,9 +42,3 @@ pages/[locale]/docs/[[...slug]].tsx
 # points --font-sans at Noto, and adds the [data-header-logo] + h1.text-heading
 # Futura rules on top of the regenerated v4 base global.css.
 src/styles/global.css
-
-# ── Wide home page override (css-wisdom PR #182 parity) ──
-# pages/index.tsx is reconstructed (no longer the locked 1-line re-export) to
-# render HomePageView with `wide`, matching the zudo-doc showcase. See the
-# file header + upstream toggle request zudolab/zudo-doc#2959.
-pages/index.tsx

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,48 +1,6 @@
-/** @jsxRuntime automatic */
-/** @jsxImportSource preact */
-// Custom home route — deliberately NOT the scaffold-default locked 1-line
-// re-export `export { default } from "@takazudo/zudo-doc/routes/index"`. That
-// package route renders HomePageView WITHOUT `wide`, and zudo-doc 4.2.1 exposes
-// no config toggle for the wide home grid, so the only way to match the
-// zudo-doc showcase is to reconstruct the route here and pass `wide`. `wide`
-// widens the content band from `max-width: 80rem` to `clamp(50rem, 92.5vw,
-// 120rem)`, letting the category grid fill the viewport (~4 cols) instead of 3.
-// Upstream request to add a config toggle so this host reconstruction is no
-// longer needed: https://github.com/zudolab/zudo-doc/issues/2959
-// Reconstruction mirrors the sanctioned self-contained pattern in
-// pages/docs/[[...slug]].tsx (same package entrypoints, no pages/lib).
-
-import type { JSX } from "preact";
-import { routeContext } from "virtual:zudo-doc-route-context";
-import {
-  createRouteContext,
-  type RouteContextPayload,
-} from "@takazudo/zudo-doc/route-context";
-import { createChrome } from "@takazudo/zudo-doc/chrome";
-import { DocHistory } from "@takazudo/zudo-doc/doc-history";
-import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";
-import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";
-import { prepareHomeData } from "@takazudo/zudo-doc/home-page";
-
-const ctx = routeContext as unknown as RouteContextPayload;
-const routeCtx = createRouteContext(ctx);
-const { HomePageView } = createChrome(routeCtx, {
-  ...chromeBindings,
-  ...defineChromeBindings({ DocHistory }),
-});
-
-export const frontmatter = { title: "Home" };
-
-export default function IndexPage(): JSX.Element {
-  const locale = routeCtx.defaultLocale;
-  const { tree, categoryOrder, tagCount } = prepareHomeData(routeCtx, locale);
-  return (
-    <HomePageView
-      locale={locale}
-      tree={tree}
-      categoryOrder={categoryOrder}
-      tagCount={tagCount}
-      wide
-    />
-  );
-}
+// Locked manifest (epic zudolab/zudo-doc#2651, Decision 4 on #2653): the home
+// route is a 1-line re-export of the package-owned STATIC index route.
+// Verified by the #2652 spike (Q2) to build, dev-render, and hydrate — a
+// dynamic route (see pages/docs/[[...slug]].tsx) cannot use this form because
+// `paths()` static-AST-extraction requires source, not compiled `dist/` JS.
+export { default } from "@takazudo/zudo-doc/routes/index";

--- a/scripts/check-category-meta.mjs
+++ b/scripts/check-category-meta.mjs
@@ -105,15 +105,25 @@ function frontmatter(source) {
 }
 
 /**
- * YAML truthiness for `category_no_page`. Accepts the spellings a YAML parser
- * treats as true — `true`, `True`, `TRUE`, `yes`, `on` — and tolerates a
- * trailing `# comment`. The original `:\s*true\s*$` form missed all of these
- * and false-greened on exactly the dead nav link this check exists to catch.
+ * Truthiness for `category_no_page`, matching what the frontmatter parser
+ * ACTUALLY produces — gray-matter/js-yaml on the YAML 1.2 core schema.
+ *
+ * Only `true` / `True` / `TRUE` become a boolean there. `yes` and `on` are
+ * YAML 1.1 spellings that the 1.2 core schema parses as the STRINGS "yes" and
+ * "on"; zudo-doc requires a boolean, so such a page is still emitted.
+ *
+ * Accepting them here was an overcorrection on my part and a false POSITIVE:
+ * the page publishes normally, but this check would report NAV-404 and fail
+ * CI. A guard that blocks correct code is worse than the gap it closed — so
+ * the accepted set is exactly the three spellings that really suppress a page.
+ * Measured against js-yaml in zudo-test-wisdom, not inferred from the spec.
+ *
+ * Still tolerates a trailing `# comment`, which the original form missed.
  */
 function hasNoPage(fm) {
   const m = fm.match(/^\s*category_no_page\s*:\s*([^#\r\n]*)/m);
   if (!m) return false;
-  return /^(true|yes|on)$/i.test(m[1].trim());
+  return /^true$/i.test(m[1].trim());
 }
 
 /**
@@ -177,10 +187,14 @@ function parseLocales(source) {
   }
   if (end === -1) return [];
   const block = source.slice(open, end);
-  return [...block.matchAll(/(\w+)\s*:\s*\{[^}]*?\bdir\s*:\s*["']([^"']+)["']/g)].map((m) => ({
-    locale: m[1],
-    dir: m[2],
-  }));
+  // Key may be bare (`ja:`) or quoted, and BCP-47 tags contain hyphens
+  // (`"pt-BR"`, `zh-Hant`). A bare-\w+ pattern skipped those locales entirely,
+  // so a localized index with category_no_page would never be inspected and CI
+  // would pass on a 404ing localized nav route — the same false-green class as
+  // the bugs above.
+  return [
+    ...block.matchAll(/["']?([\w-]+)["']?\s*:\s*\{[^}]*?\bdir\s*:\s*["']([^"']+)["']/g),
+  ].map((m) => ({ locale: m[1], dir: m[2] }));
 }
 
 const failures = [];
@@ -274,7 +288,14 @@ for (const navPath of navPaths) {
   // Check the default locale and every configured locale — a suppressed JA
   // page behind a surviving JA header link is just as much a 404.
   const targets = [{ locale: "(default)", dir: docsDir }, ...locales];
-  let resolvedAnywhere = false;
+  // Tracked for the DEFAULT locale only. Collapsing every locale into one
+  // "resolved anywhere" flag let a page that exists solely in a translation
+  // suppress the warning for the default locale — which is the route that
+  // actually 404s. A missing translation is normal and must stay silent; a
+  // missing default-locale target is exactly what we cannot verify and must
+  // say so. Cuts against this file's own "absence of findings is not evidence
+  // of correctness" rule otherwise.
+  let defaultResolved = false;
 
   for (const t of targets) {
     let resolved = null;
@@ -285,7 +306,7 @@ for (const navPath of navPaths) {
       }
     }
     if (!resolved) continue;
-    resolvedAnywhere = true;
+    if (t.locale === "(default)") defaultResolved = true;
 
     if (hasNoPage(frontmatter(await readFile(resolved, "utf-8")))) {
       failures.push(
@@ -297,10 +318,11 @@ for (const navPath of navPaths) {
     }
   }
 
-  if (!resolvedAnywhere) {
+  if (!defaultResolved) {
     warnings.push(
-      `[UNRESOLVED] headerNav "${navPath}" — no source file found in any ` +
-        `content dir. Verify this link manually; the check could not.`,
+      `[UNRESOLVED] headerNav "${navPath}" — no source file found in the ` +
+        `default content dir (${docsDir}). Verify this link manually; the ` +
+        `check could not.`,
     );
   }
 }

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -6,10 +6,11 @@
 // Verifies that related packages stay in lockstep within package.json.
 // Two version groups must be internally consistent:
 //
-//   zfb group (exact pins) — all three must be the same version:
+//   zfb group (exact pins) — all four must be the same version:
 //     dependencies["@takazudo/zfb"]
 //     dependencies["@takazudo/zfb-runtime"]
 //     dependencies["@takazudo/zfb-adapter-cloudflare"]
+//     dependencies["@takazudo/zfb-md-wasm"]
 //
 //   zudo-doc group (caret/tilde stripped before comparison) — all three
 //   must resolve to the same base version:

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -32,5 +32,10 @@ export default defineConfig(
     // Cloudflare Workers adapter — required for the Workers static-assets
     // deploy and the package-owned api-ai-chat route. Bindings via wrangler.toml.
     adapter: "@takazudo/zfb-adapter-cloudflare",
+    // Wide home grid on `/` and every locale home. Replaces the former
+    // host-reconstructed pages/index.tsx, which existed only because zudo-doc
+    // 4.2.1 had no toggle (zudolab/zudo-doc#2959); 4.4.x added `home.wide`, so
+    // the package-owned route is used again and index.tsx is back to stock.
+    home: { wide: true },
   }),
 );


### PR DESCRIPTION
## Summary

Two independent items.

**1. Canonical lint re-sync (v3).** Both shared guards re-copied byte-for-byte from `wisdom-tweaker/shared/scripts/`.

- `check-category-meta.mjs` — `parseLocales` matched locale keys with a bare `\w+` and assumed unquoted keys, so a BCP-47 tag (`"pt-BR"`) or a quoted key (`"ja"`) was skipped entirely. A localized index carrying `category_no_page` would never be inspected and CI would pass on a 404ing localized route — the same false-green class as #44. Preventive: no wisdom repo uses such a key today.
- `check-pin-parity.mjs` — header claimed "all three must be the same version" while `ZFB_PACKAGES` lists four.

Verified after syncing that the guard still does real work here rather than silently no-opping: **93 files scanned, 6 headerNav entries parsed from `src/config/settings.ts`, 2 locale dirs** (`docs` + `docs-ja`).

**2. Wide-home workaround retired.** `pages/index.tsx` was a 48-line hand-reconstruction of the package-owned home route whose sole purpose was passing `wide` to `HomePageView` — zudo-doc 4.2.1 exposed no config toggle (zudolab/zudo-doc#2959). 4.4.13 ships `HomeConfig { wide?: boolean }`, so the reconstruction is obsolete.

`pages/index.tsx` is back to the stock **6-line** re-export, byte-identical to the `create-zudo-doc` template, and `home: { wide: true }` moves into `zfb.config.ts`. The `pages/index.tsx` entry was **removed** from `.template-drift-allowlist` rather than left as permanent drift — the file now passes the drift check on its own merits. The three remaining allowlist entries (docHistory route stubs ×2, `src/styles/global.css`) are untouched.

## Visual verification

A green build proves nothing for a rendering change, so this was verified against the real page — and the first comparison produced a **false alarm worth recording**.

An early full-page capture appeared to show the grid collapsing 3 columns → 2 with a wrapped `h1`. It did not. That capture had rendered with the async-loaded Google webfonts resolved, while later captures used fallback fonts; the difference was font loading, not layout.

Settled by reverting to the original implementation, rebuilding, and measuring both states identically:

| | ORIG (hand-rolled) | NEW (`home.wide`) |
|---|---|---|
| 1280 — main / grid / cols | 1184 / 1120 / 3 @ x=80,461,843 | **identical** |
| 1440 — main / grid / cols | 1332 / 1268 / 4 × 299px | **identical** |
| full-page PNG md5 | `3d42ed5f…` | **`3d42ed5f…` — pixel-identical** |

Header nav (6 items + EN/JA), hero, card order and content all unchanged. `/ja/` renders correctly (same widths, 5 cards — JA has fewer categories).

## Test Plan

- `pnpm b4push` — **all 9 steps green**, no `B4PUSH_SKIP_*`.
- CI — **9/9 pass**.
- Visual — pixel-identical home page, verified above.