### PR TITLE
chore: re-sync scripts/check-pin-parity.mjs to canonical

### DIFF
--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -6,17 +6,17 @@
 // Verifies that related packages stay in lockstep within package.json.
 // Two version groups must be internally consistent:
 //
-//   zfb group (exact pins) — all four must be the same version:
+//   zfb group (exact pins) — all four must be the same exact version:
 //     dependencies["@takazudo/zfb"]
 //     dependencies["@takazudo/zfb-runtime"]
 //     dependencies["@takazudo/zfb-adapter-cloudflare"]
 //     dependencies["@takazudo/zfb-md-wasm"]
 //
-//   zudo-doc group (caret/tilde stripped before comparison) — all three
-//   must resolve to the same base version:
-//     dependencies["@takazudo/zudo-doc"]
-//     dependencies["@takazudo/zudo-doc-history-server"]
-//     devDependencies["create-zudo-doc"]
+//   zudo-doc group (caret/tilde stripped before comparison) — all present
+//   members must resolve to the same base version:
+//     dependencies["@takazudo/zudo-doc"]                  (required)
+//     dependencies["@takazudo/zudo-doc-history-server"]   (required)
+//     devDependencies["create-zudo-doc"]                  (OPTIONAL — see below)
 //
 // Historically, bumping one package (e.g. `pnpm up @takazudo/zfb@latest`)
 // could silently leave related packages stale. This script makes that drift
@@ -46,10 +46,39 @@ const ZFB_PACKAGES = [
   "@takazudo/zfb-md-wasm",
 ];
 
+// A bare semver only — no `^`/`~`/`>=`/other range operators. The zfb group's
+// whole point is an EXACT pin: zfb's wrangler-version gate (check-wrangler-pin.mjs)
+// assumes a single resolved version, and a range would let `pnpm install` drift the
+// four packages apart even though their package.json specifiers still compare equal.
+const EXACT_VERSION_RE = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$/;
+
+// `create-zudo-doc` is a GENERATION-DEPENDENT member of the zudo-doc group,
+// because the fleet spans two scaffold generations:
+//
+//   zudo-doc 4.x / zfb 0.1.0-next.*  — create-zudo-doc is retained as a
+//     devDependency after scaffold, so it must move in lockstep with zudo-doc.
+//   zudo-doc 5.x / zfb 2.x           — create-zudo-doc is a one-shot
+//     `pnpm create zudo-doc` CLI run and is NOT retained, so requiring it here
+//     fails a correctly-configured repo. Its version parity with zudo-doc is
+//     covered instead by check:template-drift, which resolves which
+//     create-zudo-doc release to fetch from the zudo-doc pin.
+//
+// Note the optionality is keyed on the detected zudo-doc major, NOT on "is the
+// package there?". A blanket optional-if-absent rule would make a 4.x repo that
+// silently LOST its create-zudo-doc pin indistinguishable from a legitimate 5.x
+// repo — the guard would go green on exactly the drift it exists to catch. On 4.x
+// the member stays mandatory; only on 5.x+ may it be absent, and even then absence
+// is reported as a named SKIP so "we didn't check this" can never read as "this
+// checked out fine".
 const ZUDO_DOC_PACKAGES = [
   { name: "@takazudo/zudo-doc", field: "dependencies" },
   { name: "@takazudo/zudo-doc-history-server", field: "dependencies" },
-  { name: "create-zudo-doc", field: "devDependencies" },
+  {
+    name: "create-zudo-doc",
+    field: "devDependencies",
+    optionalWhen: (major) => major >= 5,
+    optionalReason: "not retained as a devDependency by the zudo-doc 5.x scaffold; parity covered by check:template-drift",
+  },
 ];
 
 function stripRange(version) {
@@ -59,6 +88,7 @@ function stripRange(version) {
 function main() {
   const rootPkg = JSON.parse(readFileSync(ROOT_PKG_PATH, "utf-8"));
   const mismatches = [];
+  const skips = [];
 
   // ── zfb group: all exact pins must be equal ───────────────────────────────
   const zfbVersions = ZFB_PACKAGES.map((pkg) => ({
@@ -82,6 +112,14 @@ function main() {
           expected: firstZfb.version,
           actual: "(missing)",
         });
+      } else if (!EXACT_VERSION_RE.test(version)) {
+        mismatches.push({
+          group: "zfb",
+          pkg,
+          reason: `Not an exact pin (has a range operator like ^ or ~) — the zfb group requires exact versions`,
+          expected: "an exact semver, e.g. 2.2.0",
+          actual: version,
+        });
       } else if (version !== firstZfb.version) {
         mismatches.push({
           group: "zfb",
@@ -95,12 +133,22 @@ function main() {
   }
 
   // ── zudo-doc group: stripped versions must be equal ───────────────────────
-  const zudoDocVersions = ZUDO_DOC_PACKAGES.map(({ name, field }) => ({
+  const zudoDocVersions = ZUDO_DOC_PACKAGES.map(({ name, field, optionalWhen, optionalReason }) => ({
     pkg: name,
     field,
+    optionalWhen,
+    optionalReason,
     raw: rootPkg[field]?.[name],
     stripped: stripRange(rootPkg[field]?.[name]),
   }));
+
+  // Generation is read off @takazudo/zudo-doc, the one package present in every
+  // generation. NaN when it is missing/unparseable, which fails every optionalWhen
+  // predicate — so an unreadable pin makes members MORE required, not less.
+  const zudoDocMajor = Number.parseInt(
+    stripRange(rootPkg.dependencies?.["@takazudo/zudo-doc"]) ?? "",
+    10,
+  );
 
   const firstZudoDoc = zudoDocVersions.find((e) => e.raw !== undefined);
   if (!firstZudoDoc) {
@@ -109,8 +157,12 @@ function main() {
       reason: `None of the zudo-doc packages found`,
     });
   } else {
-    for (const { pkg, field, raw, stripped } of zudoDocVersions) {
+    for (const { pkg, field, optionalWhen, optionalReason, raw, stripped } of zudoDocVersions) {
       if (raw === undefined) {
+        if (optionalWhen?.(zudoDocMajor)) {
+          skips.push(`${pkg} (${field}) — ${optionalReason}`);
+          continue;
+        }
         mismatches.push({
           group: "zudo-doc",
           pkg,
@@ -136,14 +188,18 @@ function main() {
   if (mismatches.length === 0) {
     const zfbVer = firstZfb?.version ?? "(unknown)";
     const zudoDocVer = firstZudoDoc?.stripped ?? "(unknown)";
+    const checkedZudoDoc = zudoDocVersions.filter((e) => e.raw !== undefined);
     console.log(`OK — pin parity verified:`);
-    console.log(`  zfb group (${ZFB_PACKAGES.length} packages) = ${zfbVer}`);
+    console.log(`  zfb group (${zfbVersions.length} packages checked) = ${zfbVer}`);
     for (const { pkg, version } of zfbVersions) {
       console.log(`    ${pkg} = ${version}`);
     }
-    console.log(`  zudo-doc group (${ZUDO_DOC_PACKAGES.length} packages) = ${zudoDocVer}`);
-    for (const { pkg, field, raw } of zudoDocVersions) {
+    console.log(`  zudo-doc group (${checkedZudoDoc.length} of ${ZUDO_DOC_PACKAGES.length} packages checked) = ${zudoDocVer}`);
+    for (const { pkg, field, raw } of checkedZudoDoc) {
       console.log(`    ${pkg} (${field}) = ${raw}`);
+    }
+    for (const s of skips) {
+      console.log(`  ⏭  SKIPPED: ${s}`);
     }
     return 0;
   }
@@ -165,6 +221,9 @@ function main() {
       console.error(`    raw:      ${m.raw}`);
     }
     console.error("");
+  }
+  for (const s of skips) {
+    console.error(`  ⏭  SKIPPED: ${s}`);
   }
   console.error("Fix: align the version(s) in package.json, then re-run this check.");
   return 1;


### PR DESCRIPTION
## Summary

Re-syncs `scripts/check-pin-parity.mjs` to the current canonical copy in the wisdom-tweaker
control repo (`shared/scripts/check-pin-parity.mjs`). This file is distributed verbatim to every
`*-wisdom` repo; per-repo edits are forbidden, so this is a mechanical copy — no local changes.

Three behavior changes arrive from canonical:

1. **zfb group now requires exact pins.** A `^`/`~` range operator on any of the four
   `@takazudo/zfb*` packages is rejected — a range would let `pnpm install` drift them apart while
   their specifiers still compare equal. This repo already pins them exactly at `0.1.0-next.99`.
2. **`create-zudo-doc` optionality is keyed on the detected zudo-doc major.** It became optional only
   for the newer zfb 2.x / zudo-doc 5.x scaffold generation (which does not retain it as a
   devDependency). **This repo is on zudo-doc 4.x, so the member stays MANDATORY here — unchanged.**
3. **Skipped members print a named `SKIPPED` line** rather than being silently omitted.

## Changes

- `scripts/check-pin-parity.mjs` — replaced with the canonical copy (byte-identical).

## Test Plan

`pnpm check:pin-parity` exits 0, checking all 4 zfb packages and all 3 zudo-doc members (none
skipped, correct for 4.x). `pnpm b4push` passes all 9 checks.

A green guard proves nothing unless it can go red, so the instrument was checked against controls
in a sandbox (the repo's own `package.json`, mutated; working tree untouched):

| control | expected | result |
|---|---|---|
| unmodified `package.json` | pass | exit 0 |
| `^` added to `@takazudo/zfb-runtime` | fail — range operator | exit 1, "Not an exact pin" |
| `create-zudo-doc` removed, zudo-doc **4.x** | fail — still mandatory | exit 1, "Missing from devDependencies" |
| `create-zudo-doc` removed, zudo-doc **5.x** | pass, with named skip | exit 0, `SKIPPED: create-zudo-doc` |

The last two rows are the pair that matters: they show the new optionality is genuinely keyed on the
major and has not silently relaxed the check for this repo.

Verify byte-identity with the control repo:

    diff /path/to/wisdom-tweaker/shared/scripts/check-pin-parity.mjs scripts/check-pin-parity.mjs