### PR TITLE
fix: restore the site's own home-hero logo (set logo: /img/logo.svg)

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -43,6 +43,11 @@ export const settings = {
   } satisfies ColorModeConfig as ColorModeConfig | false,
   siteName: "zudo-codemirror-wisdom",
   siteDescription: "Takazudo's CodeMirror 6 dev notes for me and AI agents" as string,
+  // Home-hero logo. MUST stay explicit: zudo-doc defaults `logo` to "auto",
+  // which renders a generated placeholder SVG seeded by siteName and silently
+  // shadows this site's own brand mark. Rendered as a theme-adaptive CSS mask,
+  // so the asset's fill colors are ignored by design.
+  logo: "/img/logo.svg" as string | false,
   base: "/",
   trailingSlash: false as boolean,
   // Preserve the 3.1.0 (unminified) HTML baseline. v4 defaults minifyHtml to


### PR DESCRIPTION
## Summary

The home hero was rendering zudo-doc's generated `AutoLogo` placeholder — a deterministic SVG seeded by `siteName`, which came out as a generic bookmark glyph — instead of this site's own brand mark.

Nothing was deleted: `public/img/logo.svg` has been present and correct the whole time. zudo-doc's `logo` setting defaults to `"auto"` (added in 4.4.0; this repo is on 5.2.1) and this repo never set it, so `HomePageView` simply never referenced the asset.

## Changes

- `src/config/settings.ts`: add `logo: "/img/logo.svg"`, plus a comment recording why it must stay explicit.

That is the entire diff — 5 lines, one file. `public/img/logo.svg` is untouched.

The setting goes in `src/config/settings.ts` rather than `zfb.config.ts` because that is where this repo keeps its zudoDoc settings (`siteName`, `locales`, `headerNav`, `footer`, `metaTags`, …), spread into `zudoDoc({ ...settings })`. `zfb.config.ts` carries only host-shell fields (directives, port, adapter, home).

## Test Plan

A green build proves nothing here, so the hero was measured directly in a browser, with a **before/after control** to prove the instrument discriminates. Both builds were served locally and probed at a **1440x900 viewport-sized** capture (never `fullPage`).

The two code paths are trivially distinguishable in zudo-doc's `dist/home-page/index.js`: `"auto"` renders an inline `<svg>` AutoLogo (`text-fg`); a path string renders a `<div>` (`bg-fg`) carrying a CSS mask.

| measurement | before (control) | after |
|---|---|---|
| hero logo element | `<svg data-auto-logo="bookmark">` | `<div class="…aspect-[1200/630] bg-fg shrink-0">` |
| computed `mask-image` | `none` | `url("…/img/logo.svg")` |
| computed `-webkit-mask-image` | `none` | `url("…/img/logo.svg")` |
| `mask-repeat` / `mask-size` | `repeat` / `auto` | `no-repeat` / `contain` |
| `data-auto-logo` in built HTML | 1 | **0** |
| inline `<svg>` count in hero | 2 | **1** (the GitHub icon only) |
| box size | 320x168 | 320x168 (unchanged) |

- Verified identically on the default-locale home `/` **and** the `ja` locale home `/ja/` (`locales` declares only `ja`). All four page loads returned HTTP 200 with **zero console errors**.
- `/img/logo.svg` serves **200, 54093 bytes** from the built site — the mask target resolves, so this is not a 404 masking to nothing.
- **Screenshot control:** before and after differ by 23,855 px (1.84% of frame), max channel delta 226/255, and the diff bounding box is exactly `(293,112)-(613,280)` — 320x168, precisely the hero logo box. Nothing else on the page moved. Identical result for `/ja/`.
- `pnpm b4push`: **all 9 checks pass** (format, category-meta, template-drift, pin-parity, wrangler-pin, `zfb check`, build, html-validate, link check).

### Known, pre-existing — not introduced here

The "W" in the asset is a `<text>` element set in `BodoniSvtyTwoOSITCTT-Book` / `Bodoni 72 Oldstyle`, a macOS system font. Consumed as a CSS mask image the SVG cannot load external fonts, so on Linux the W falls back to a generic serif. This is a property of the asset, unchanged by this PR.

Likewise the asset's paths are all `fill:#fff` by design — it is a mask silhouette, painted via `bg-fg`, so it stays theme-adaptive.